### PR TITLE
Fxlemire/snippets fix

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,3862 +1,3863 @@
-{"hook_actions_delete":{  
-   "prefix":"hook_actions_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_actions_delete().",
-      " */",
-      "function hook_actions_delete($aid) {","  $1","}"
-   ],
-   "description":"Executes code after an action is deleted.",
-   "scope":"text.php"
-},
-"hook_action_info":{  
-   "prefix":"hook_action_info",
-   "body":[  
-      "/**",
-      " * Implements hook_action_info().",
-      " */",
-      "function hook_action_info() {","  $1","}"
-   ],
-   "description":"Declares information about actions.",
-   "scope":"text.php"
-},
-"hook_action_info_alter":{  
-   "prefix":"hook_action_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_action_info_alter().",
-      " */",
-      "function hook_action_info_alter(&$actions) {","  $1","}"
-   ],
-   "description":"Alters the actions declared by another module.",
-   "scope":"text.php"
-},
-"hook_admin_paths":{  
-   "prefix":"hook_admin_paths",
-   "body":[  
-      "/**",
-      " * Implements hook_admin_paths().",
-      " */",
-      "function hook_admin_paths() {","  $1","}"
-   ],
-   "description":"Define administrative paths.",
-   "scope":"text.php"
-},
-"hook_admin_paths_alter":{  
-   "prefix":"hook_admin_paths_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_admin_paths_alter().",
-      " */",
-      "function hook_admin_paths_alter(&$paths)hook_aggregator_fetch($feed) {","  $1","}"
-   ],
-   "description":"Redefine administrative paths defined by other modules.",
-   "scope":"text.php"
-},
-"hook_aggregator_fetch":{  
-   "prefix":"hook_aggregator_fetch",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_fetch().",
-      " */",
-      "function hook_aggregator_fetch_info() {","  $1","}"
-   ],
-   "description":"Create an alternative fetcher for aggregator.module.",
-   "scope":"text.php"
-},
-"hook_aggregator_fetch_info":{  
-   "prefix":"hook_aggregator_fetch_info",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_fetch_info().",
-      " */",
-      "function hook_aggregator_parse($feed) {","  $1","}"
-   ],
-   "description":"Specify the title and short description of your fetcher.",
-   "scope":"text.php"
-},
-"hook_aggregator_parse":{  
-   "prefix":"hook_aggregator_parse",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_parse().",
-      " */",
-      "function hook_aggregator_parse_info() {","  $1","}"
-   ],
-   "description":"Create an alternative parser for aggregator module.",
-   "scope":"text.php"
-},
-"hook_aggregator_parse_info":{  
-   "prefix":"hook_aggregator_parse_info",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_parse_info().",
-      " */",
-      "function hook_aggregator_process($feed) {","  $1","}"
-   ],
-   "description":"Specify the title and short description of your parser.",
-   "scope":"text.php"
-},
-"hook_aggregator_process":{  
-   "prefix":"hook_aggregator_process",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_process().",
-      " */",
-      "function hook_aggregator_process_info() {","  $1","}"
-   ],
-   "description":"Create a processor for aggregator.module.",
-   "scope":"text.php"
-},
-"hook_aggregator_process_info":{  
-   "prefix":"hook_aggregator_process_info",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_process_info().",
-      " */",
-      "function hook_aggregator_process_info() {","  $1","}"
-   ],
-   "description":"Specify the title and short description of your processor.",
-   "scope":"text.php"
-},
-"hook_aggregator_remove":{  
-   "prefix":"hook_aggregator_remove",
-   "body":[  
-      "/**",
-      " * Implements hook_aggregator_remove().",
-      " */",
-      "function hook_aggregator_remove($feed) {","  $1","}"
-   ],
-   "description":"Remove stored feed data.",
-   "scope":"text.php"
-},
-"hook_ajax_render_alter":{  
-   "prefix":"hook_ajax_render_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_ajax_render_alter().",
-      " */",
-      "function hook_ajax_render_alter(array &$data) {","  $1","}"
-   ],
-   "description":"Alter the commands that are sent to the user through the Ajax framework.",
-   "scope":"text.php"
-},
-"hook_archiver_info":{  
-   "prefix":"hook_archiver_info",
-   "body":[  
-      "/**",
-      " * Implements hook_archiver_info().",
-      " */",
-      "function hook_archiver_info() {","  $1","}"
-   ],
-   "description":"Declare archivers to the system.",
-   "scope":"text.php"
-},
-"hook_archiver_info_alter":{  
-   "prefix":"hook_archiver_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_archiver_info_alter().",
-      " */",
-      "function hook_archiver_info_alter(&$info) {","  $1","}"
-   ],
-   "description":"Alter archiver information declared by other modules.",
-   "scope":"text.php"
-},
-"hook_batch_alter":{  
-   "prefix":"hook_batch_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_batch_alter().",
-      " */",
-      "function hook_batch_alter(&$batch) {","  $1","}"
-   ],
-   "description":"Alter batch information before a batch is processed.",
-   "scope":"text.php"
-},
-"hook_block_cid_parts_alter":{  
-   "prefix":"hook_block_cid_parts_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_block_cid_parts_alter().",
-      " */",
-      "function hook_block_cid_parts_alter(&$cid_parts, $block) {","  $1","}"
-   ],
-   "description":"Act on block cache ID (cid) parts before the cid is generated.",
-   "scope":"text.php"
-},
-"hook_block_configure":{  
-   "prefix":"hook_block_configure",
-   "body":[  
-      "/**",
-      " * Implements hook_block_configure().",
-      " */",
-      "function hook_block_configure($delta = '') {","  $1","}"
-   ],
-   "description":"Define a configuration form for a block.",
-   "scope":"text.php"
-},
-"hook_block_info":{  
-   "prefix":"hook_block_info",
-   "body":[  
-      "/**",
-      " * Implements hook_block_info().",
-      " */",
-      "function hook_block_info() {","  $1","}"
-   ],
-   "description":"Define all blocks provided by the module.",
-   "scope":"text.php"
-},
-"hook_block_info_alter":{  
-   "prefix":"hook_block_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_block_info_alter().",
-      " */",
-      "function hook_block_info_alter(&$blocks, $theme, $code_blocks) {","  $1","}"
-   ],
-   "description":"Change block definition before saving to the database.",
-   "scope":"text.php"
-},
-"hook_block_list_alter":{  
-   "prefix":"hook_block_list_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_block_list_alter().",
-      " */",
-      "function hook_block_list_alter(&$blocks) {","  $1","}"
-   ],
-   "description":"Act on blocks prior to rendering.",
-   "scope":"text.php"
-},
-"hook_block_save":{  
-   "prefix":"hook_block_save",
-   "body":[  
-      "/**",
-      " * Implements hook_block_save().",
-      " */",
-      "function hook_block_save($delta = '', $edit = array()) {","  $1","}"
-   ],
-   "description":"Save the configuration options from hook_block_configure().",
-   "scope":"text.php"
-},
-"hook_block_view":{  
-   "prefix":"hook_block_view",
-   "body":[  
-      "/**",
-      " * Implements hook_block_view().",
-      " */",
-      "function hook_block_view($delta = '') {","  $1","}"
-   ],
-   "description":"Return a rendered or renderable view of a block.",
-   "scope":"text.php"
-},
-"hook_block_view_alter":{  
-   "prefix":"hook_block_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_block_view_alter().",
-      " */",
-      "function hook_block_view_alter(array &$build, \\Drupal\\Core\\Block\\BlockPluginInterface $block) {","  $1","}"
-   ],
-   "description":"Perform alterations to the content of a block.",
-   "scope":"text.php"
-},
-"hook_block_view_MODULE_DELTA_alter":{  
-   "prefix":"hook_block_view_MODULE_DELTA_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_block_view_MODULE_DELTA_alter().",
-      " */",
-      "function hook_block_view_MODULE_DELTA_alter(&$data, $block) {","  $1","}"
-   ],
-   "description":"Perform alterations to a specific block.",
-   "scope":"text.php"
-},
-"hook_boot":{  
-   "prefix":"hook_boot",
-   "body":[  
-      "/**",
-      " * Implements hook_boot().",
-      " */",
-      "function hook_boot() {","  $1","}"
-   ],
-   "description":"Perform setup tasks for all page requests.",
-   "scope":"text.php"
-},
-"hook_comment_delete":{  
-   "prefix":"hook_comment_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_delete().",
-      " */",
-      "function hook_comment_delete($comment) {","  $1","}"
-   ],
-   "description":"The comment is being deleted by the moderator.",
-   "scope":"text.php"
-},
-"hook_comment_insert":{  
-   "prefix":"hook_comment_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_insert().",
-      " */",
-      "function hook_comment_insert($comment) {","  $1","}"
-   ],
-   "description":"The comment is being inserted.",
-   "scope":"text.php"
-},
-"hook_comment_load":{  
-   "prefix":"hook_comment_load",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_load().",
-      " */",
-      "function hook_comment_load($comments) {","  $1","}"
-   ],
-   "description":"Comments are being loaded from the database.",
-   "scope":"text.php"
-},
-"hook_comment_presave":{  
-   "prefix":"hook_comment_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_presave().",
-      " */",
-      "function hook_comment_presave($comment) {","  $1","}"
-   ],
-   "description":"The comment passed validation and is about to be saved.",
-   "scope":"text.php"
-},
-"hook_comment_publish":{  
-   "prefix":"hook_comment_publish",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_publish().",
-      " */",
-      "function hook_comment_publish($comment) {","  $1","}"
-   ],
-   "description":"The comment is being published by the moderator.",
-   "scope":"text.php"
-},
-"hook_comment_unpublish":{  
-   "prefix":"hook_comment_unpublish",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_unpublish().",
-      " */",
-      "function hook_comment_unpublish($comment) {","  $1","}"
-   ],
-   "description":"The comment is being unpublished by the moderator.",
-   "scope":"text.php"
-},
-"hook_comment_update":{  
-   "prefix":"hook_comment_update",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_update().",
-      " */",
-      "function hook_comment_update($comment) {","  $1","}"
-   ],
-   "description":"The comment is being updated.",
-   "scope":"text.php"
-},
-"hook_comment_view":{  
-   "prefix":"hook_comment_view",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_view().",
-      " */",
-      "function hook_comment_view($comment, $view_mode, $langcode) {","  $1","}"
-   ],
-   "description":"The comment is being viewed. This hook can be used to add additional data to the comment before theming.",
-   "scope":"text.php"
-},
-"hook_comment_view_alter":{  
-   "prefix":"hook_comment_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_comment_view_alter().",
-      " */",
-      "function hook_comment_view_alter(&$build) {","  $1","}"
-   ],
-   "description":"The comment was built; the module may modify the structured content.",
-   "scope":"text.php"
-},
-"hook_contextual_links_view_alter":{  
-   "prefix":"hook_contextual_links_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_contextual_links_view_alter().",
-      " */",
-      "function hook_contextual_links_view_alter(&$element, $items) {","  $1","}"
-   ],
-   "description":"Alter a contextual links element before it is rendered.",
-   "scope":"text.php"
-},
-"hook_countries_alter":{  
-   "prefix":"hook_countries_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_countries_alter().",
-      " */",
-      "function hook_countries_alter(&$countries)hook_cron() {","  $1","}"
-   ],
-   "description":"Alter the default country list.",
-   "scope":"text.php"
-},
-"hook_cron":{  
-   "prefix":"hook_cron",
-   "body":[  
-      "/**",
-      " * Implements hook_cron().",
-      " */",
-      "function hook_cron() {","  $1","}"
-   ],
-   "description":"Perform periodic actions.",
-   "scope":"text.php"
-},
-"hook_cron_queue_info":{  
-   "prefix":"hook_cron_queue_info",
-   "body":[  
-      "/**",
-      " * Implements hook_cron_queue_info().",
-      " */",
-      "function hook_cron_queue_info() {","  $1","}"
-   ],
-   "description":"Declare queues holding items that need to be run periodically.",
-   "scope":"text.php"
-},
-"hook_cron_queue_info_alter":{  
-   "prefix":"hook_cron_queue_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_cron_queue_info_alter().",
-      " */",
-      "function hook_cron_queue_info_alter(&$queues) {","  $1","}"
-   ],
-   "description":"Alter cron queue information before cron runs.",
-   "scope":"text.php"
-},
-"hook_css_alter":{  
-   "prefix":"hook_css_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_css_alter().",
-      " */",
-      "function hook_css_alter(&$css) {","  $1","}"
-   ],
-   "description":"Alter CSS files before they are output on the page.",
-   "scope":"text.php"
-},
-"hook_custom_theme":{  
-   "prefix":"hook_custom_theme",
-   "body":[  
-      "/**",
-      " * Implements hook_custom_theme().",
-      " */",
-      "function hook_custom_theme() {","  $1","}"
-   ],
-   "description":"Return the machine-readable name of the theme to use for the current page.",
-   "scope":"text.php"
-},
-"hook_dashboard_regions":{  
-   "prefix":"hook_dashboard_regions",
-   "body":[  
-      "/**",
-      " * Implements hook_dashboard_regions().",
-      " */",
-      "function hook_dashboard_regions() {","  $1","}"
-   ],
-   "description":"Add regions to the dashboard.",
-   "scope":"text.php"
-},
-"hook_dashboard_regions_alter":{  
-   "prefix":"hook_dashboard_regions_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_dashboard_regions_alter().",
-      " */",
-      "function hook_dashboard_regions_alter(&$regions) {","  $1","}"
-   ],
-   "description":"Alter dashboard regions provided by modules.",
-   "scope":"text.php"
-},
-"hook_date_formats":{  
-   "prefix":"hook_date_formats",
-   "body":[  
-      "/**",
-      " * Implements hook_date_formats().",
-      " */",
-      "function hook_date_formats() {","  $1","}"
-   ],
-   "description":"Define additional date formats.",
-   "scope":"text.php"
-},
-"hook_date_formats_alter":{  
-   "prefix":"hook_date_formats_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_date_formats_alter().",
-      " */",
-      "function hook_date_formats_alter(&$formats) {","  $1","}"
-   ],
-   "description":"Alter date formats declared by another module.",
-   "scope":"text.php"
-},
-"hook_date_format_types":{  
-   "prefix":"hook_date_format_types",
-   "body":[  
-      "/**",
-      " * Implements hook_date_format_types().",
-      " */",
-      "function hook_date_format_types() {","  $1","}"
-   ],
-   "description":"Define additional date types.",
-   "scope":"text.php"
-},
-"hook_date_format_types_alter":{  
-   "prefix":"hook_date_format_types_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_date_format_types_alter().",
-      " */",
-      "function hook_date_format_types_alter(&$types) {","  $1","}"
-   ],
-   "description":"Modify existing date types.",
-   "scope":"text.php"
-},
-"hook_delete":{  
-   "prefix":"hook_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_delete().",
-      " */",
-      "function hook_delete($node)hook_disable() {","  $1","}"
-   ],
-   "description":"Respond to node deletion.",
-   "scope":"text.php"
-},
-"hook_disable":{  
-   "prefix":"hook_disable",
-   "body":[  
-      "/**",
-      " * Implements hook_disable().",
-      " */",
-      "function hook_disable() {","  $1","}"
-   ],
-   "description":"Perform necessary actions before module is disabled.",
-   "scope":"text.php"
-},
-"hook_drupal_goto_alter":{  
-   "prefix":"hook_drupal_goto_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_drupal_goto_alter().",
-      " */",
-      "function hook_drupal_goto_alter(&$path, &$options, &$http_response_code) {","  $1","}"
-   ],
-   "description":"Change the page the user is sent to by drupal_goto().",
-   "scope":"text.php"
-},
-"hook_element_info":{  
-   "prefix":"hook_element_info",
-   "body":[  
-      "/**",
-      " * Implements hook_element_info().",
-      " */",
-      "function hook_element_info() {","  $1","}"
-   ],
-   "description":"Allows modules to declare their own Form API element types and specify their default values.",
-   "scope":"text.php"
-},
-"hook_element_info_alter":{  
-   "prefix":"hook_element_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_element_info_alter().",
-      " */",
-      "function hook_element_info_alter(array &$types) {","  $1","}"
-   ],
-   "description":"Alter the element type information returned from modules.",
-   "scope":"text.php"
-},
-"hook_enable":{  
-   "prefix":"hook_enable",
-   "body":[  
-      "/**",
-      " * Implements hook_enable().",
-      " */",
-      "function hook_enable() {","  $1","}"
-   ],
-   "description":"Perform necessary actions after module is enabled.",
-   "scope":"text.php"
-},
-"hook_entity_delete":{  
-   "prefix":"hook_entity_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_delete().",
-      " */",
-      "function hook_entity_delete(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
-   ],
-   "description":"Act on entities when deleted.",
-   "scope":"text.php"
-},
-"hook_entity_info":{  
-   "prefix":"hook_entity_info",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_info().",
-      " */",
-      "function hook_entity_info() {","  $1","}"
-   ],
-   "description":"Inform the base system and the Field API about one or more entity types.",
-   "scope":"text.php"
-},
-"hook_entity_info_alter":{  
-   "prefix":"hook_entity_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_info_alter().",
-      " */",
-      "function hook_entity_info_alter(&$entity_info) {","  $1","}"
-   ],
-   "description":"Alter the entity info.",
-   "scope":"text.php"
-},
-"hook_entity_insert":{  
-   "prefix":"hook_entity_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_insert().",
-      " */",
-      "function hook_entity_insert(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
-   ],
-   "description":"Act on entities when inserted.",
-   "scope":"text.php"
-},
-"hook_entity_load":{  
-   "prefix":"hook_entity_load",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_load().",
-      " */",
-      "function hook_entity_load(array $entities, $entity_type_id) {","  $1","}"
-   ],
-   "description":"Act on entities when loaded.",
-   "scope":"text.php"
-},
-"hook_entity_prepare_view":{  
-   "prefix":"hook_entity_prepare_view",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_prepare_view().",
-      " */",
-      "function hook_entity_prepare_view($entity_type_id, array $entities, array $displays, $view_mode) {","  $1","}"
-   ],
-   "description":"Act on entities as they are being prepared for view.",
-   "scope":"text.php"
-},
-"hook_entity_presave":{  
-   "prefix":"hook_entity_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_presave().",
-      " */",
-      "function hook_entity_presave(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
-   ],
-   "description":"Act on an entity before it is about to be created or updated.",
-   "scope":"text.php"
-},
-"hook_entity_query_alter":{  
-   "prefix":"hook_entity_query_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_query_alter().",
-      " */",
-      "function hook_entity_query_alter(\\Drupal\\Core\\Entity\\Query\\QueryInterface $query) {","  $1","}"
-   ],
-   "description":"Alter or execute an EntityFieldQuery.",
-   "scope":"text.php"
-},
-"hook_entity_update":{  
-   "prefix":"hook_entity_update",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_update().",
-      " */",
-      "function hook_entity_update(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
-   ],
-   "description":"Act on entities when updated.",
-   "scope":"text.php"
-},
-"hook_entity_view":{  
-   "prefix":"hook_entity_view",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_view().",
-      " */",
-      "function hook_entity_view(array &$build, \\Drupal\\Core\\Entity\\EntityInterface $entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface $display, $view_mode) {","  $1","}"
-   ],
-   "description":"Act on entities being assembled before rendering.",
-   "scope":"text.php"
-},
-"hook_entity_view_alter":{  
-   "prefix":"hook_entity_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_view_alter().",
-      " */",
-      "function hook_entity_view_alter(array &$build, Drupal\\Core\\Entity\\EntityInterface $entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface $display) {","  $1","}"
-   ],
-   "description":"Alter the results of ENTITY_view().",
-   "scope":"text.php"
-},
-"hook_entity_view_mode_alter":{  
-   "prefix":"hook_entity_view_mode_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_entity_view_mode_alter().",
-      " */",
-      "function hook_entity_view_mode_alter(&$view_mode, Drupal\\Core\\Entity\\EntityInterface $entity, $context) {","  $1","}"
-   ],
-   "description":"Change the view mode of an entity that is being displayed.",
-   "scope":"text.php"
-},
-"hook_exit":{  
-   "prefix":"hook_exit",
-   "body":[  
-      "/**",
-      " * Implements hook_exit().",
-      " */",
-      "function hook_exit($destination = NULL) {","  $1","}"
-   ],
-   "description":"Perform cleanup tasks.",
-   "scope":"text.php"
-},
-"hook_field_access":{  
-   "prefix":"hook_field_access",
-   "body":[  
-      "/**",
-      " * Implements hook_field_access().",
-      " */",
-      "function hook_field_access($op, $field, $entity_type, $entity, $account) {","  $1","}"
-   ],
-   "description":"Determine whether the user has access to a given field.",
-   "scope":"text.php"
-},
-"hook_field_attach_create_bundle":{  
-   "prefix":"hook_field_attach_create_bundle",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_create_bundle().",
-      " */",
-      "function hook_field_attach_create_bundle($entity_type, $bundle) {","  $1","}"
-   ],
-   "description":"Act on field_attach_create_bundle().",
-   "scope":"text.php"
-},
-"hook_field_attach_delete":{  
-   "prefix":"hook_field_attach_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_delete().",
-      " */",
-      "function hook_field_attach_delete($entity_type, $entity) {","  $1","}"
-   ],
-   "description":"Act on field_attach_delete().",
-   "scope":"text.php"
-},
-"hook_field_attach_delete_bundle":{  
-   "prefix":"hook_field_attach_delete_bundle",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_delete_bundle().",
-      " */",
-      "function hook_field_attach_delete_bundle($entity_type, $bundle, $instances) {","  $1","}"
-   ],
-   "description":"Act on field_attach_delete_bundle.",
-   "scope":"text.php"
-},
-"hook_field_attach_delete_revision":{  
-   "prefix":"hook_field_attach_delete_revision",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_delete_revision().",
-      " */",
-      "function hook_field_attach_delete_revision($entity_type, $entity) {","  $1","}"
-   ],
-   "description":"Act on field_attach_delete_revision().",
-   "scope":"text.php"
-},
-"hook_field_attach_form":{  
-   "prefix":"hook_field_attach_form",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_form().",
-      " */",
-      "function hook_field_attach_form($entity_type, $entity, &$form, &$form_state, $langcode) {","  $1","}"
-   ],
-   "description":"Act on field_attach_form().",
-   "scope":"text.php"
-},
-"hook_field_attach_insert":{  
-   "prefix":"hook_field_attach_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_insert().",
-      " */",
-      "function hook_field_attach_insert($entity_type, $entity) {","  $1","}"
-   ],
-   "description":"Act on field_attach_insert().",
-   "scope":"text.php"
-},
-"hook_field_attach_load":{  
-   "prefix":"hook_field_attach_load",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_load().",
-      " */",
-      "function hook_field_attach_load($entity_type, $entities, $age, $options) {","  $1","}"
-   ],
-   "description":"Act on field_attach_load().",
-   "scope":"text.php"
-},
-"hook_field_attach_prepare_translation_alter":{  
-   "prefix":"hook_field_attach_prepare_translation_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_prepare_translation_alter().",
-      " */",
-      "function hook_field_attach_prepare_translation_alter(&$entity, $context) {","  $1","}"
-   ],
-   "description":"Perform alterations on field_attach_prepare_translation().",
-   "scope":"text.php"
-},
-"hook_field_attach_preprocess_alter":{  
-   "prefix":"hook_field_attach_preprocess_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_preprocess_alter().",
-      " */",
-      "function hook_field_attach_preprocess_alter(&$variables, $context) {","  $1","}"
-   ],
-   "description":"Alter field_attach_preprocess() variables.",
-   "scope":"text.php"
-},
-"hook_field_attach_presave":{  
-   "prefix":"hook_field_attach_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_presave().",
-      " */",
-      "function hook_field_attach_presave($entity_type, $entity) {","  $1","}"
-   ],
-   "description":"Act on field_attach_presave().",
-   "scope":"text.php"
-},
-"hook_field_attach_purge":{  
-   "prefix":"hook_field_attach_purge",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_purge().",
-      " */",
-      "function hook_field_attach_purge($entity_type, $entity, $field, $instance) {","  $1","}"
-   ],
-   "description":"Act on field_purge_data().",
-   "scope":"text.php"
-},
-"hook_field_attach_rename_bundle":{  
-   "prefix":"hook_field_attach_rename_bundle",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_rename_bundle().",
-      " */",
-      "function hook_field_attach_rename_bundle($entity_type, $bundle_old, $bundle_new) {","  $1","}"
-   ],
-   "description":"Act on field_attach_rename_bundle().",
-   "scope":"text.php"
-},
-"hook_field_attach_submit":{  
-   "prefix":"hook_field_attach_submit",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_submit().",
-      " */",
-      "function hook_field_attach_submit($entity_type, $entity, $form, &$form_state) {","  $1","}"
-   ],
-   "description":"Act on field_attach_submit().",
-   "scope":"text.php"
-},
-"hook_field_attach_update":{  
-   "prefix":"hook_field_attach_update",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_update().",
-      " */",
-      "function hook_field_attach_update($entity_type, $entity) {","  $1","}"
-   ],
-   "description":"Act on field_attach_update().",
-   "scope":"text.php"
-},
-"hook_field_attach_validate":{  
-   "prefix":"hook_field_attach_validate",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_validate().",
-      " */",
-      "function hook_field_attach_validate($entity_type, $entity, &$errors) {","  $1","}"
-   ],
-   "description":"Act on field_attach_validate().",
-   "scope":"text.php"
-},
-"hook_field_attach_view_alter":{  
-   "prefix":"hook_field_attach_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_attach_view_alter().",
-      " */",
-      "function hook_field_attach_view_alter(&$output, $context) {","  $1","}"
-   ],
-   "description":"Perform alterations on field_attach_view() or field_view_field().",
-   "scope":"text.php"
-},
-"hook_field_available_languages_alter":{  
-   "prefix":"hook_field_available_languages_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_available_languages_alter().",
-      " */",
-      "function hook_field_available_languages_alter(&$languages, $context) {","  $1","}"
-   ],
-   "description":"Alter field_available_languages() values.",
-   "scope":"text.php"
-},
-"hook_field_create_field":{  
-   "prefix":"hook_field_create_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_create_field().",
-      " */",
-      "function hook_field_create_field($field) {","  $1","}"
-   ],
-   "description":"Act on a field being created.",
-   "scope":"text.php"
-},
-"hook_field_create_instance":{  
-   "prefix":"hook_field_create_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_create_instance().",
-      " */",
-      "function hook_field_create_instance($instance) {","  $1","}"
-   ],
-   "description":"Act on a field instance being created.",
-   "scope":"text.php"
-},
-"hook_field_delete":{  
-   "prefix":"hook_field_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_field_delete().",
-      " */",
-      "function hook_field_delete($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Define custom delete behavior for this module's field data.",
-   "scope":"text.php"
-},
-"hook_field_delete_field":{  
-   "prefix":"hook_field_delete_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_delete_field().",
-      " */",
-      "function hook_field_delete_field($field) {","  $1","}"
-   ],
-   "description":"Act on a field being deleted.",
-   "scope":"text.php"
-},
-"hook_field_delete_instance":{  
-   "prefix":"hook_field_delete_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_delete_instance().",
-      " */",
-      "function hook_field_delete_instance($instance) {","  $1","}"
-   ],
-   "description":"Act on a field instance being deleted.",
-   "scope":"text.php"
-},
-"hook_field_delete_revision":{  
-   "prefix":"hook_field_delete_revision",
-   "body":[  
-      "/**",
-      " * Implements hook_field_delete_revision().",
-      " */",
-      "function hook_field_delete_revision($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Define custom revision delete behavior for this module's field types.",
-   "scope":"text.php"
-},
-"hook_field_display_alter":{  
-   "prefix":"hook_field_display_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_display_alter().",
-      " */",
-      "function hook_field_display_alter(&$display, $context) {","  $1","}"
-   ],
-   "description":"Alters the display settings of a field before it gets displayed.",
-   "scope":"text.php"
-},
-"hook_field_display_ENTITY_TYPE_alter":{  
-   "prefix":"hook_field_display_ENTITY_TYPE_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_display_ENTITY_TYPE_alter().",
-      " */",
-      "function hook_field_display_ENTITY_TYPE_alter(&$display, $context) {","  $1","}"
-   ],
-   "description":"Alters the display settings of a field on a given entity type before it gets displayed.",
-   "scope":"text.php"
-},
-"hook_field_extra_fields":{  
-   "prefix":"hook_field_extra_fields",
-   "body":[  
-      "/**",
-      " * Implements hook_field_extra_fields().",
-      " */",
-      "function hook_field_extra_fields() {","  $1","}"
-   ],
-   "description":"Exposes pseudo-field components on fieldable entities.",
-   "scope":"text.php"
-},
-"hook_field_extra_fields_alter":{  
-   "prefix":"hook_field_extra_fields_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_extra_fields_alter().",
-      " */",
-      "function hook_field_extra_fields_alter(&$info) {","  $1","}"
-   ],
-   "description":"Alter pseudo-field components on fieldable entities.",
-   "scope":"text.php"
-},
-"hook_field_extra_fields_display_alter":{  
-   "prefix":"hook_field_extra_fields_display_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_extra_fields_display_alter().",
-      " */",
-      "function hook_field_extra_fields_display_alter(&$displays, $context) {","  $1","}"
-   ],
-   "description":"Alters the display settings of pseudo-fields before an entity is displayed.",
-   "scope":"text.php"
-},
-"hook_field_formatter_info":{  
-   "prefix":"hook_field_formatter_info",
-   "body":[  
-      "/**",
-      " * Implements hook_field_formatter_info().",
-      " */",
-      "function hook_field_formatter_info() {","  $1","}"
-   ],
-   "description":"Expose Field API formatter types.",
-   "scope":"text.php"
-},
-"hook_field_formatter_info_alter":{  
-   "prefix":"hook_field_formatter_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_formatter_info_alter().",
-      " */",
-      "function hook_field_formatter_info_alter(array &$info) {","  $1","}"
-   ],
-   "description":"Perform alterations on Field API formatter types.",
-   "scope":"text.php"
-},
-"hook_field_formatter_prepare_view":{  
-   "prefix":"hook_field_formatter_prepare_view",
-   "body":[  
-      "/**",
-      " * Implements hook_field_formatter_prepare_view().",
-      " */",
-      "function hook_field_formatter_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items, $displays) {","  $1","}"
-   ],
-   "description":"Allow formatters to load information for field values being displayed.",
-   "scope":"text.php"
-},
-"hook_field_formatter_view":{  
-   "prefix":"hook_field_formatter_view",
-   "body":[  
-      "/**",
-      " * Implements hook_field_formatter_view().",
-      " */",
-      "function hook_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {","  $1","}"
-   ],
-   "description":"Build a renderable array for a field value.",
-   "scope":"text.php"
-},
-"hook_field_info":{  
-   "prefix":"hook_field_info",
-   "body":[  
-      "/**",
-      " * Implements hook_field_info().",
-      " */",
-      "function hook_field_info() {","  $1","}"
-   ],
-   "description":"Define Field API field types.",
-   "scope":"text.php"
-},
-"hook_field_info_alter":{  
-   "prefix":"hook_field_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_info_alter().",
-      " */",
-      "function hook_field_info_alter(&$info) {","  $1","}"
-   ],
-   "description":"Perform alterations on Field API field types.",
-   "scope":"text.php"
-},
-"hook_field_info_max_weight":{  
-   "prefix":"hook_field_info_max_weight",
-   "body":[  
-      "/**",
-      " * Implements hook_field_info_max_weight().",
-      " */",
-      "function hook_field_info_max_weight($entity_type, $bundle, $context, $context_mode) {","  $1","}"
-   ],
-   "description":"Returns the maximum weight for the entity components handled by the module.",
-   "scope":"text.php"
-},
-"hook_field_insert":{  
-   "prefix":"hook_field_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_field_insert().",
-      " */",
-      "function hook_field_insert($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Define custom insert behavior for this module's field data.",
-   "scope":"text.php"
-},
-"hook_field_is_empty":{  
-   "prefix":"hook_field_is_empty",
-   "body":[  
-      "/**",
-      " * Implements hook_field_is_empty().",
-      " */",
-      "function hook_field_is_empty($item, $field) {","  $1","}"
-   ],
-   "description":"Define what constitutes an empty item for a field type.",
-   "scope":"text.php"
-},
-"hook_field_language_alter":{  
-   "prefix":"hook_field_language_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_language_alter().",
-      " */",
-      "function hook_field_language_alter(&$display_language, $context) {","  $1","}"
-   ],
-   "description":"Perform alterations on field_language() values.",
-   "scope":"text.php"
-},
-"hook_field_load":{  
-   "prefix":"hook_field_load",
-   "body":[  
-      "/**",
-      " * Implements hook_field_load().",
-      " */",
-      "function hook_field_load($entity_type, $entities, $field, $instances, $langcode, &$items, $age) {","  $1","}"
-   ],
-   "description":"Define custom load behavior for this module's field types.",
-   "scope":"text.php"
-},
-"hook_field_prepare_translation":{  
-   "prefix":"hook_field_prepare_translation",
-   "body":[  
-      "/**",
-      " * Implements hook_field_prepare_translation().",
-      " */",
-      "function hook_field_prepare_translation($entity_type, $entity, $field, $instance, $langcode, &$items, $source_entity, $source_langcode) {","  $1","}"
-   ],
-   "description":"Define custom prepare_translation behavior for this module's field types.",
-   "scope":"text.php"
-},
-"hook_field_prepare_view":{  
-   "prefix":"hook_field_prepare_view",
-   "body":[  
-      "/**",
-      " * Implements hook_field_prepare_view().",
-      " */",
-      "function hook_field_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Prepare field values prior to display.",
-   "scope":"text.php"
-},
-"hook_field_presave":{  
-   "prefix":"hook_field_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_field_presave().",
-      " */",
-      "function hook_field_presave($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Define custom presave behavior for this module's field types.",
-   "scope":"text.php"
-},
-"hook_field_purge_field":{  
-   "prefix":"hook_field_purge_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_purge_field().",
-      " */",
-      "function hook_field_purge_field(\\Drupal\\field\\Entity\\FieldConfig $field) {","  $1","}"
-   ],
-   "description":"Acts when a field record is being purged.",
-   "scope":"text.php"
-},
-"hook_field_purge_instance":{  
-   "prefix":"hook_field_purge_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_purge_instance().",
-      " */",
-      "function hook_field_purge_instance($instance) {","  $1","}"
-   ],
-   "description":"Acts when a field instance is being purged.",
-   "scope":"text.php"
-},
-"hook_field_read_field":{  
-   "prefix":"hook_field_read_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_read_field().",
-      " */",
-      "function hook_field_read_field($field) {","  $1","}"
-   ],
-   "description":"Act on field records being read from the database.",
-   "scope":"text.php"
-},
-"hook_field_read_instance":{  
-   "prefix":"hook_field_read_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_read_instance().",
-      " */",
-      "function hook_field_read_instance($instance) {","  $1","}"
-   ],
-   "description":"Act on a field record being read from the database.",
-   "scope":"text.php"
-},
-"hook_field_schema":{  
-   "prefix":"hook_field_schema",
-   "body":[  
-      "/**",
-      " * Implements hook_field_schema().",
-      " */",
-      "function hook_field_schema($field) {","  $1","}"
-   ],
-   "description":"Define the Field API schema for a field structure.",
-   "scope":"text.php"
-},
-"hook_field_storage_create_field":{  
-   "prefix":"hook_field_storage_create_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_create_field().",
-      " */",
-      "function hook_field_storage_create_field($field) {","  $1","}"
-   ],
-   "description":"Act on creation of a new field.",
-   "scope":"text.php"
-},
-"hook_field_storage_delete":{  
-   "prefix":"hook_field_storage_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_delete().",
-      " */",
-      "function hook_field_storage_delete($entity_type, $entity, $fields) {","  $1","}"
-   ],
-   "description":"Delete all field data for an entity.",
-   "scope":"text.php"
-},
-"hook_field_storage_delete_field":{  
-   "prefix":"hook_field_storage_delete_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_delete_field().",
-      " */",
-      "function hook_field_storage_delete_field($field) {","  $1","}"
-   ],
-   "description":"Act on deletion of a field.",
-   "scope":"text.php"
-},
-"hook_field_storage_delete_instance":{  
-   "prefix":"hook_field_storage_delete_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_delete_instance().",
-      " */",
-      "function hook_field_storage_delete_instance($instance) {","  $1","}"
-   ],
-   "description":"Act on deletion of a field instance.",
-   "scope":"text.php"
-},
-"hook_field_storage_delete_revision":{  
-   "prefix":"hook_field_storage_delete_revision",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_delete_revision().",
-      " */",
-      "function hook_field_storage_delete_revision($entity_type, $entity, $fields) {","  $1","}"
-   ],
-   "description":"Delete a single revision of field data for an entity.",
-   "scope":"text.php"
-},
-"hook_field_storage_details":{  
-   "prefix":"hook_field_storage_details",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_details().",
-      " */",
-      "function hook_field_storage_details($field) {","  $1","}"
-   ],
-   "description":"Reveal the internal details about the storage for a field.",
-   "scope":"text.php"
-},
-"hook_field_storage_details_alter":{  
-   "prefix":"hook_field_storage_details_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_details_alter().",
-      " */",
-      "function hook_field_storage_details_alter(&$details, $field) {","  $1","}"
-   ],
-   "description":"Perform alterations on Field API storage details.",
-   "scope":"text.php"
-},
-"hook_field_storage_info":{  
-   "prefix":"hook_field_storage_info",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_info().",
-      " */",
-      "function hook_field_storage_info() {","  $1","}"
-   ],
-   "description":"Expose Field API storage backends.",
-   "scope":"text.php"
-},
-"hook_field_storage_info_alter":{  
-   "prefix":"hook_field_storage_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_info_alter().",
-      " */",
-      "function hook_field_storage_info_alter(&$info) {","  $1","}"
-   ],
-   "description":"Perform alterations on Field API storage types.",
-   "scope":"text.php"
-},
-"hook_field_storage_load":{  
-   "prefix":"hook_field_storage_load",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_load().",
-      " */",
-      "function hook_field_storage_load($entity_type, $entities, $age, $fields, $options) {","  $1","}"
-   ],
-   "description":"Load field data for a set of entities.",
-   "scope":"text.php"
-},
-"hook_field_storage_pre_insert":{  
-   "prefix":"hook_field_storage_pre_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_pre_insert().",
-      " */",
-      "function hook_field_storage_pre_insert($entity_type, $entity, &$skip_fields) {","  $1","}"
-   ],
-   "description":"Act before the storage backends insert field data.",
-   "scope":"text.php"
-},
-"hook_field_storage_pre_load":{  
-   "prefix":"hook_field_storage_pre_load",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_pre_load().",
-      " */",
-      "function hook_field_storage_pre_load($entity_type, $entities, $age, &$skip_fields, $options) {","  $1","}"
-   ],
-   "description":"Act before the storage backends load field data.",
-   "scope":"text.php"
-},
-"hook_field_storage_pre_update":{  
-   "prefix":"hook_field_storage_pre_update",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_pre_update().",
-      " */",
-      "function hook_field_storage_pre_update($entity_type, $entity, &$skip_fields) {","  $1","}"
-   ],
-   "description":"Act before the storage backends update field data.",
-   "scope":"text.php"
-},
-"hook_field_storage_purge":{  
-   "prefix":"hook_field_storage_purge",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_purge().",
-      " */",
-      "function hook_field_storage_purge($entity_type, $entity, $field, $instance) {","  $1","}"
-   ],
-   "description":"Remove field storage information when field data is purged.",
-   "scope":"text.php"
-},
-"hook_field_storage_purge_field":{  
-   "prefix":"hook_field_storage_purge_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_purge_field().",
-      " */",
-      "function hook_field_storage_purge_field($field) {","  $1","}"
-   ],
-   "description":"Remove field storage information when a field record is purged.",
-   "scope":"text.php"
-},
-"hook_field_storage_purge_field_instance":{  
-   "prefix":"hook_field_storage_purge_field_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_purge_field_instance().",
-      " */",
-      "function hook_field_storage_purge_field_instance($instance) {","  $1","}"
-   ],
-   "description":"Remove field storage information when a field instance is purged.",
-   "scope":"text.php"
-},
-"hook_field_storage_query":{  
-   "prefix":"hook_field_storage_query",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_query().",
-      " */",
-      "function hook_field_storage_query($query) {","  $1","}"
-   ],
-   "description":"Execute an EntityFieldQuery.",
-   "scope":"text.php"
-},
-"hook_field_storage_update_field":{  
-   "prefix":"hook_field_storage_update_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_update_field().",
-      " */",
-      "function hook_field_storage_update_field($field, $prior_field, $has_data) {","  $1","}"
-   ],
-   "description":"Update the storage information for a field.",
-   "scope":"text.php"
-},
-"hook_field_storage_write":{  
-   "prefix":"hook_field_storage_write",
-   "body":[  
-      "/**",
-      " * Implements hook_field_storage_write().",
-      " */",
-      "function hook_field_storage_write($entity_type, $entity, $op, $fields) {","  $1","}"
-   ],
-   "description":"Write field data for an entity.",
-   "scope":"text.php"
-},
-"hook_field_update":{  
-   "prefix":"hook_field_update",
-   "body":[  
-      "/**",
-      " * Implements hook_field_update().",
-      " */",
-      "function hook_field_update($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
-   ],
-   "description":"Define custom update behavior for this module's field data.",
-   "scope":"text.php"
-},
-"hook_field_update_field":{  
-   "prefix":"hook_field_update_field",
-   "body":[  
-      "/**",
-      " * Implements hook_field_update_field().",
-      " */",
-      "function hook_field_update_field($field, $prior_field, $has_data) {","  $1","}"
-   ],
-   "description":"Act on a field being updated.",
-   "scope":"text.php"
-},
-"hook_field_update_forbid":{  
-   "prefix":"hook_field_update_forbid",
-   "body":[  
-      "/**",
-      " * Implements hook_field_update_forbid().",
-      " */",
-      "function hook_field_update_forbid($field, $prior_field, $has_data) {","  $1","}"
-   ],
-   "description":"Forbid a field update from occurring.",
-   "scope":"text.php"
-},
-"hook_field_update_instance":{  
-   "prefix":"hook_field_update_instance",
-   "body":[  
-      "/**",
-      " * Implements hook_field_update_instance().",
-      " */",
-      "function hook_field_update_instance($instance, $prior_instance) {","  $1","}"
-   ],
-   "description":"Act on a field instance being updated.",
-   "scope":"text.php"
-},
-"hook_field_validate":{  
-   "prefix":"hook_field_validate",
-   "body":[  
-      "/**",
-      " * Implements hook_field_validate().",
-      " */",
-      "function hook_field_validate($entity_type, $entity, $field, $instance, $langcode, $items, &$errors) {","  $1","}"
-   ],
-   "description":"Validate this module's field data.",
-   "scope":"text.php"
-},
-"hook_field_widget_error":{  
-   "prefix":"hook_field_widget_error",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_error().",
-      " */",
-      "function hook_field_widget_error($element, $error, $form, &$form_state) {","  $1","}"
-   ],
-   "description":"Flag a field-level validation error.",
-   "scope":"text.php"
-},
-"hook_field_widget_form":{  
-   "prefix":"hook_field_widget_form",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_form().",
-      " */",
-      "function hook_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {","  $1","}"
-   ],
-   "description":"Return the form for a single field widget.",
-   "scope":"text.php"
-},
-"hook_field_widget_form_alter":{  
-   "prefix":"hook_field_widget_form_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_form_alter().",
-      " */",
-      "function hook_field_widget_form_alter(&$element, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $context) {","  $1","}"
-   ],
-   "description":"Alter forms for field widgets provided by other modules.",
-   "scope":"text.php"
-},
-"hook_field_widget_info":{  
-   "prefix":"hook_field_widget_info",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_info().",
-      " */",
-      "function hook_field_widget_info() {","  $1","}"
-   ],
-   "description":"Expose Field API widget types.",
-   "scope":"text.php"
-},
-"hook_field_widget_info_alter":{  
-   "prefix":"hook_field_widget_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_info_alter().",
-      " */",
-      "function hook_field_widget_info_alter(array &$info) {","  $1","}"
-   ],
-   "description":"Perform alterations on Field API widget types.",
-   "scope":"text.php"
-},
-"hook_field_widget_properties_alter":{  
-   "prefix":"hook_field_widget_properties_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_properties_alter().",
-      " */",
-      "function hook_field_widget_properties_alter(&$widget, $context) {","  $1","}"
-   ],
-   "description":"Alters the widget properties of a field instance before it gets displayed.",
-   "scope":"text.php"
-},
-"hook_field_widget_properties_ENTITY_TYPE_alter":{  
-   "prefix":"hook_field_widget_properties_ENTITY_TYPE_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_properties_ENTITY_TYPE_alter().",
-      " */",
-      "function hook_field_widget_properties_ENTITY_TYPE_alter(&$widget, $context) {","  $1","}"
-   ],
-   "description":"Alters the widget properties of a field instance on a given entity type before it gets displayed.",
-   "scope":"text.php"
-},
-"hook_field_widget_WIDGET_TYPE_form_alter":{  
-   "prefix":"hook_field_widget_WIDGET_TYPE_form_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_field_widget_WIDGET_TYPE_form_alter().",
-      " */",
-      "function hook_field_widget_WIDGET_TYPE_form_alter(&$element, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $context) {","  $1","}"
-   ],
-   "description":"Alter widget forms for a specific widget provided by another module.",
-   "scope":"text.php"
-},
-"hook_filetransfer_info":{  
-   "prefix":"hook_filetransfer_info",
-   "body":[  
-      "/**",
-      " * Implements hook_filetransfer_info().",
-      " */",
-      "function hook_filetransfer_info() {","  $1","}"
-   ],
-   "description":"Register information about FileTransfer classes provided by a module.",
-   "scope":"text.php"
-},
-"hook_filetransfer_info_alter":{  
-   "prefix":"hook_filetransfer_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_filetransfer_info_alter().",
-      " */",
-      "function hook_filetransfer_info_alter(&$filetransfer_info) {","  $1","}"
-   ],
-   "description":"Alter the FileTransfer class registry.",
-   "scope":"text.php"
-},
-"hook_file_copy":{  
-   "prefix":"hook_file_copy",
-   "body":[  
-      "/**",
-      " * Implements hook_file_copy().",
-      " */",
-      "function hook_file_copy(Drupal\\file\\FileInterface $file, Drupal\\file\\FileInterface $source) {","  $1","}"
-   ],
-   "description":"Respond to a file that has been copied.",
-   "scope":"text.php"
-},
-"hook_file_delete":{  
-   "prefix":"hook_file_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_file_delete().",
-      " */",
-      "function hook_file_delete($file) {","  $1","}"
-   ],
-   "description":"Respond to a file being deleted.",
-   "scope":"text.php"
-},
-"hook_file_download":{  
-   "prefix":"hook_file_download",
-   "body":[  
-      "/**",
-      " * Implements hook_file_download().",
-      " */",
-      "function hook_file_download($uri) {","  $1","}"
-   ],
-   "description":"Control access to private file downloads and specify HTTP headers.",
-   "scope":"text.php"
-},
-"hook_file_insert":{  
-   "prefix":"hook_file_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_file_insert().",
-      " */",
-      "function hook_file_insert($file) {","  $1","}"
-   ],
-   "description":"Respond to a file being added.",
-   "scope":"text.php"
-},
-"hook_file_load":{  
-   "prefix":"hook_file_load",
-   "body":[  
-      "/**",
-      " * Implements hook_file_load().",
-      " */",
-      "function hook_file_load($files) {","  $1","}"
-   ],
-   "description":"Load additional information into file objects.",
-   "scope":"text.php"
-},
-"hook_file_mimetype_mapping_alter":{  
-   "prefix":"hook_file_mimetype_mapping_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_file_mimetype_mapping_alter().",
-      " */",
-      "function hook_file_mimetype_mapping_alter(&$mapping) {","  $1","}"
-   ],
-   "description":"Alter MIME type mappings used to determine MIME type from a file extension.",
-   "scope":"text.php"
-},
-"hook_file_move":{  
-   "prefix":"hook_file_move",
-   "body":[  
-      "/**",
-      " * Implements hook_file_move().",
-      " */",
-      "function hook_file_move(Drupal\\file\\FileInterface $file, Drupal\\file\\FileInterface $source) {","  $1","}"
-   ],
-   "description":"Respond to a file that has been moved.",
-   "scope":"text.php"
-},
-"hook_file_presave":{  
-   "prefix":"hook_file_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_file_presave().",
-      " */",
-      "function hook_file_presave($file) {","  $1","}"
-   ],
-   "description":"Act on a file being inserted or updated.",
-   "scope":"text.php"
-},
-"hook_file_update":{  
-   "prefix":"hook_file_update",
-   "body":[  
-      "/**",
-      " * Implements hook_file_update().",
-      " */",
-      "function hook_file_update($file) {","  $1","}"
-   ],
-   "description":"Respond to a file being updated.",
-   "scope":"text.php"
-},
-"hook_file_url_alter":{  
-   "prefix":"hook_file_url_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_file_url_alter().",
-      " */",
-      "function hook_file_url_alter(&$uri) {","  $1","}"
-   ],
-   "description":"Alter the URL to a file.",
-   "scope":"text.php"
-},
-"hook_file_validate":{  
-   "prefix":"hook_file_validate",
-   "body":[  
-      "/**",
-      " * Implements hook_file_validate().",
-      " */",
-      "function hook_file_validate(Drupal\\file\\FileInterface $file) {","  $1","}"
-   ],
-   "description":"Check that files meet a given criteria.",
-   "scope":"text.php"
-},
-"hook_filter_format_disable":{  
-   "prefix":"hook_filter_format_disable",
-   "body":[  
-      "/**",
-      " * Implements hook_filter_format_disable().",
-      " */",
-      "function hook_filter_format_disable($format) {","  $1","}"
-   ],
-   "description":"Perform actions when a text format has been disabled.",
-   "scope":"text.php"
-},
-"hook_filter_format_insert":{  
-   "prefix":"hook_filter_format_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_filter_format_insert().",
-      " */",
-      "function hook_filter_format_insert($format) {","  $1","}"
-   ],
-   "description":"Perform actions when a new text format has been created.",
-   "scope":"text.php"
-},
-"hook_filter_format_update":{  
-   "prefix":"hook_filter_format_update",
-   "body":[  
-      "/**",
-      " * Implements hook_filter_format_update().",
-      " */",
-      "function hook_filter_format_update($format) {","  $1","}"
-   ],
-   "description":"Perform actions when a text format has been updated.",
-   "scope":"text.php"
-},
-"hook_filter_info":{  
-   "prefix":"hook_filter_info",
-   "body":[  
-      "/**",
-      " * Implements hook_filter_info().",
-      " */",
-      "function hook_filter_info() {","  $1","}"
-   ],
-   "description":"Define content filters.",
-   "scope":"text.php"
-},
-"hook_filter_info_alter":{  
-   "prefix":"hook_filter_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_filter_info_alter().",
-      " */",
-      "function hook_filter_info_alter(&$info) {","  $1","}"
-   ],
-   "description":"Perform alterations on filter definitions.",
-   "scope":"text.php"
-},
-"hook_flush_caches":{  
-   "prefix":"hook_flush_caches",
-   "body":[  
-      "/**",
-      " * Implements hook_flush_caches().",
-      " */",
-      "function hook_flush_caches() {","  $1","}"
-   ],
-   "description":"Add a list of cache tables to be cleared.",
-   "scope":"text.php"
-},
-"hook_form":{  
-   "prefix":"hook_form",
-   "body":[  
-      "/**",
-      " * Implements hook_form().",
-      " */",
-      "function hook_form($node, &$form_state) {","  $1","}"
-   ],
-   "description":"Display a node editing form.",
-   "scope":"text.php"
-},
-"hook_forms":{  
-   "prefix":"hook_forms",
-   "body":[  
-      "/**",
-      " * Implements hook_forms().",
-      " */",
-      "function hook_forms() {","  $1","}"
-   ],
-   "description":"Map form_ids to form builder functions.",
-   "scope":"text.php"
-},
-"hook_form_alter":{  
-   "prefix":"hook_form_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_form_alter().",
-      " */",
-      "function hook_form_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
-   ],
-   "description":"Perform alterations before a form is rendered.",
-   "scope":"text.php"
-},
-"hook_form_BASE_FORM_ID_alter":{  
-   "prefix":"hook_form_BASE_FORM_ID_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_form_BASE_FORM_ID_alter().",
-      " */",
-      "function hook_form_BASE_FORM_ID_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
-   ],
-   "description":"Provide a form-specific alteration for shared ('base') forms.",
-   "scope":"text.php"
-},
-"hook_form_FORM_ID_alter":{  
-   "prefix":"hook_form_FORM_ID_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_form_FORM_ID_alter().",
-      " */",
-      "function hook_form_FORM_ID_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
-   ],
-   "description":"Provide a form-specific alteration instead of the global hook_form_alter().",
-   "scope":"text.php"
-},
-"hook_help":{  
-   "prefix":"hook_help",
-   "body":[  
-      "/**",
-      " * Implements hook_help().",
-      " */",
-      "function hook_help($route_name, \\Drupal\\Core\\Routing\\RouteMatchInterface $route_match) {","  $1","}"
-   ],
-   "description":"Provide online user help.",
-   "scope":"text.php"
-},
-"hook_hook_info":{  
-   "prefix":"hook_hook_info",
-   "body":[  
-      "/**",
-      " * Implements hook_hook_info().",
-      " */",
-      "function hook_hook_info() {","  $1","}"
-   ],
-   "description":"Defines one or more hooks that are exposed by a module.",
-   "scope":"text.php"
-},
-"hook_hook_info_alter":{  
-   "prefix":"hook_hook_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_hook_info_alter().",
-      " */",
-      "function hook_hook_info_alter(&$hooks) {","  $1","}"
-   ],
-   "description":"Alter information from hook_hook_info().",
-   "scope":"text.php"
-},
-"hook_html_head_alter":{  
-   "prefix":"hook_html_head_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_html_head_alter().",
-      " */",
-      "function hook_html_head_alter(&$head_elements) {","  $1","}"
-   ],
-   "description":"Alter XHTML HEAD tags before they are rendered by drupal_get_html_head().",
-   "scope":"text.php"
-},
-"hook_image_default_styles":{  
-   "prefix":"hook_image_default_styles",
-   "body":[  
-      "/**",
-      " * Implements hook_image_default_styles().",
-      " */",
-      "function hook_image_default_styles() {","  $1","}"
-   ],
-   "description":"Provide module-based image styles for reuse throughout Drupal.",
-   "scope":"text.php"
-},
-"hook_image_effect_info":{  
-   "prefix":"hook_image_effect_info",
-   "body":[  
-      "/**",
-      " * Implements hook_image_effect_info().",
-      " */",
-      "function hook_image_effect_info() {","  $1","}"
-   ],
-   "description":"Define information about image effects provided by a module.",
-   "scope":"text.php"
-},
-"hook_image_effect_info_alter":{  
-   "prefix":"hook_image_effect_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_image_effect_info_alter().",
-      " */",
-      "function hook_image_effect_info_alter(&$effects) {","  $1","}"
-   ],
-   "description":"Alter the information provided in hook_image_effect_info().",
-   "scope":"text.php"
-},
-"hook_image_styles_alter":{  
-   "prefix":"hook_image_styles_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_image_styles_alter().",
-      " */",
-      "function hook_image_styles_alter(&$styles) {","  $1","}"
-   ],
-   "description":"Modify any image styles provided by other modules or the user.",
-   "scope":"text.php"
-},
-"hook_image_style_delete":{  
-   "prefix":"hook_image_style_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_image_style_delete().",
-      " */",
-      "function hook_image_style_delete($style) {","  $1","}"
-   ],
-   "description":"Respond to image style deletion.",
-   "scope":"text.php"
-},
-"hook_image_style_flush":{  
-   "prefix":"hook_image_style_flush",
-   "body":[  
-      "/**",
-      " * Implements hook_image_style_flush().",
-      " */",
-      "function hook_image_style_flush($style) {","  $1","}"
-   ],
-   "description":"Respond to image style flushing.",
-   "scope":"text.php"
-},
-"hook_image_style_save":{  
-   "prefix":"hook_image_style_save",
-   "body":[  
-      "/**",
-      " * Implements hook_image_style_save().",
-      " */",
-      "function hook_image_style_save($style) {","  $1","}"
-   ],
-   "description":"Respond to image style updating.",
-   "scope":"text.php"
-},
-"hook_image_toolkits":{  
-   "prefix":"hook_image_toolkits",
-   "body":[  
-      "/**",
-      " * Implements hook_image_toolkits().",
-      " */",
-      "function hook_image_toolkits()hook_init() {","  $1","}"
-   ],
-   "description":"Define image toolkits provided by this module.",
-   "scope":"text.php"
-},
-"hook_init":{  
-   "prefix":"hook_init",
-   "body":[  
-      "/**",
-      " * Implements hook_init().",
-      " */",
-      "function hook_insert($node) {","  $1","}"
-   ],
-   "description":"Perform setup tasks for non-cached page requests.",
-   "scope":"text.php"
-},
-"hook_insert":{  
-   "prefix":"hook_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_insert().",
-      " */",
-      "function hook_install() {","  $1","}"
-   ],
-   "description":"Respond to creation of a new node.",
-   "scope":"text.php"
-},
-"hook_install":{  
-   "prefix":"hook_install",
-   "body":[  
-      "/**",
-      " * Implements hook_install().",
-      " */",
-      "function hook_install_tasks(&$install_state) {","  $1","}"
-   ],
-   "description":"Perform setup tasks when the module is installed.",
-   "scope":"text.php"
-},
-"hook_install_tasks":{  
-   "prefix":"hook_install_tasks",
-   "body":[  
-      "/**",
-      " * Implements hook_install_tasks().",
-      " */",
-      "function hook_install_tasks(&$install_state) {","  $1","}"
-   ],
-   "description":"Return an array of tasks to be performed by an installation profile.",
-   "scope":"text.php"
-},
-"hook_install_tasks_alter":{  
-   "prefix":"hook_install_tasks_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_install_tasks_alter().",
-      " */",
-      "function hook_install_tasks_alter(&$tasks, $install_state) {","  $1","}"
-   ],
-   "description":"Alter the full list of installation tasks.",
-   "scope":"text.php"
-},
-"hook_js_alter":{  
-   "prefix":"hook_js_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_js_alter().",
-      " */",
-      "function hook_js_alter(&$javascript, \\Drupal\\Core\\Asset\\AttachedAssetsInterface $assets) {","  $1","}"
-   ],
-   "description":"Perform necessary alterations to the JavaScript before it is presented on the page.",
-   "scope":"text.php"
-},
-"hook_language_fallback_candidates_alter":{  
-   "prefix":"hook_language_fallback_candidates_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_language_fallback_candidates_alter().",
-      " */",
-      "function hook_language_fallback_candidates_alter(array &$candidates, array $context) {","  $1","}"
-   ],
-   "description":"Perform alterations on the language fallback candidates.",
-   "scope":"text.php"
-},
-"hook_language_init":{  
-   "prefix":"hook_language_init",
-   "body":[  
-      "/**",
-      " * Implements hook_language_init().",
-      " */",
-      "function hook_language_init() {","  $1","}"
-   ],
-   "description":"Allows modules to act after language initialization has been performed.",
-   "scope":"text.php"
-},
-"hook_language_negotiation_info":{  
-   "prefix":"hook_language_negotiation_info",
-   "body":[  
-      "/**",
-      " * Implements hook_language_negotiation_info().",
-      " */",
-      "function hook_language_negotiation_info() {","  $1","}"
-   ],
-   "description":"Define language negotiation providers.",
-   "scope":"text.php"
-},
-"hook_language_negotiation_info_alter":{  
-   "prefix":"hook_language_negotiation_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_language_negotiation_info_alter().",
-      " */",
-      "function hook_language_negotiation_info_alter(array &$negotiation_info) {","  $1","}"
-   ],
-   "description":"Perform alterations on language negoiation providers.",
-   "scope":"text.php"
-},
-"hook_language_switch_links_alter":{  
-   "prefix":"hook_language_switch_links_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_language_switch_links_alter().",
-      " */",
-      "function hook_language_switch_links_alter(array &$links, $type, $path) {","  $1","}"
-   ],
-   "description":"Perform alterations on language switcher links.",
-   "scope":"text.php"
-},
-"hook_language_types_info":{  
-   "prefix":"hook_language_types_info",
-   "body":[  
-      "/**",
-      " * Implements hook_language_types_info().",
-      " */",
-      "function hook_language_types_info() {","  $1","}"
-   ],
-   "description":"Define language types.",
-   "scope":"text.php"
-},
-"hook_language_types_info_alter":{  
-   "prefix":"hook_language_types_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_language_types_info_alter().",
-      " */",
-      "function hook_language_types_info_alter(array &$language_types) {","  $1","}"
-   ],
-   "description":"Perform alterations on language types.",
-   "scope":"text.php"
-},
-"hook_library":{  
-   "prefix":"hook_library",
-   "body":[  
-      "/**",
-      " * Implements hook_library().",
-      " */",
-      "function hook_library() {","  $1","}"
-   ],
-   "description":"Registers JavaScript/CSS libraries associated with a module.",
-   "scope":"text.php"
-},
-"hook_library_alter":{  
-   "prefix":"hook_library_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_library_alter().",
-      " */",
-      "function hook_library_alter(&$libraries, $module) {","  $1","}"
-   ],
-   "description":"Alters the JavaScript/CSS library registry.",
-   "scope":"text.php"
-},
-"hook_load":{  
-   "prefix":"hook_load",
-   "body":[  
-      "/**",
-      " * Implements hook_load().",
-      " */",
-      "function hook_load($nodes) {","  $1","}"
-   ],
-   "description":"Act on nodes being loaded from the database.",
-   "scope":"text.php"
-},
-"hook_locale":{  
-   "prefix":"hook_locale",
-   "body":[  
-      "/**",
-      " * Implements hook_locale().",
-      " */",
-      "function hook_locale($op = 'groups') {","  $1","}"
-   ],
-   "description":"Allows modules to define their own text groups that can be translated.",
-   "scope":"text.php"
-},
-"hook_mail":{  
-   "prefix":"hook_mail",
-   "body":[  
-      "/**",
-      " * Implements hook_mail().",
-      " */",
-      "function hook_mail($key, &$message, $params) {","  $1","}"
-   ],
-   "description":"Prepare a message based on parameters; called from drupal_mail().",
-   "scope":"text.php"
-},
-"hook_mail_alter":{  
-   "prefix":"hook_mail_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_mail_alter().",
-      " */",
-      "function hook_mail_alter(&$message) {","  $1","}"
-   ],
-   "description":"Alter an email message created with the drupal_mail() function.",
-   "scope":"text.php"
-},
-"hook_menu":{  
-   "prefix":"hook_menu",
-   "body":[  
-      "/**",
-      " * Implements hook_menu().",
-      " */",
-      "function hook_menu($may_cache) {","  $1","}"
-   ],
-   "description":"Define menu items and page callbacks.",
-   "scope":"text.php"
-},
-"hook_menu_alter":{  
-   "prefix":"hook_menu_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_alter().",
-      " */",
-      "function hook_menu_alter(&$items) {","  $1","}"
-   ],
-   "description":"Alter the data being saved to the {menu_router} table after hook_menu is invoked.",
-   "scope":"text.php"
-},
-"hook_menu_breadcrumb_alter":{  
-   "prefix":"hook_menu_breadcrumb_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_breadcrumb_alter().",
-      " */",
-      "function hook_menu_breadcrumb_alter(&$active_trail, $item) {","  $1","}"
-   ],
-   "description":"Alter links in the active trail before it is rendered as the breadcrumb.",
-   "scope":"text.php"
-},
-"hook_menu_contextual_links_alter":{  
-   "prefix":"hook_menu_contextual_links_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_contextual_links_alter().",
-      " */",
-      "function hook_menu_contextual_links_alter(&$links, $router_item, $root_path) {","  $1","}"
-   ],
-   "description":"Alter contextual links before they are rendered.",
-   "scope":"text.php"
-},
-"hook_menu_delete":{  
-   "prefix":"hook_menu_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_delete().",
-      " */",
-      "function hook_menu_delete($menu) {","  $1","}"
-   ],
-   "description":"Respond to a custom menu deletion.",
-   "scope":"text.php"
-},
-"hook_menu_get_item_alter":{  
-   "prefix":"hook_menu_get_item_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_get_item_alter().",
-      " */",
-      "function hook_menu_get_item_alter(&$router_item, $path, $original_map) {","  $1","}"
-   ],
-   "description":"Alter a menu router item right after it has been retrieved from the database or cache.",
-   "scope":"text.php"
-},
-"hook_menu_insert":{  
-   "prefix":"hook_menu_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_insert().",
-      " */",
-      "function hook_menu_insert($menu) {","  $1","}"
-   ],
-   "description":"Respond to a custom menu creation.",
-   "scope":"text.php"
-},
-"hook_menu_link_alter":{  
-   "prefix":"hook_menu_link_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_link_alter().",
-      " */",
-      "function hook_menu_link_alter(&$item, $menu) {","  $1","}"
-   ],
-   "description":"Alter the data being saved to the {menu_links} table by menu_link_save().",
-   "scope":"text.php"
-},
-"hook_menu_link_delete":{  
-   "prefix":"hook_menu_link_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_link_delete().",
-      " */",
-      "function hook_menu_link_delete($link) {","  $1","}"
-   ],
-   "description":"Inform modules that a menu link has been deleted.",
-   "scope":"text.php"
-},
-"hook_menu_link_insert":{  
-   "prefix":"hook_menu_link_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_link_insert().",
-      " */",
-      "function hook_menu_link_insert($link) {","  $1","}"
-   ],
-   "description":"Inform modules that a menu link has been created.",
-   "scope":"text.php"
-},
-"hook_menu_link_update":{  
-   "prefix":"hook_menu_link_update",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_link_update().",
-      " */",
-      "function hook_menu_link_update($link) {","  $1","}"
-   ],
-   "description":"Inform modules that a menu link has been updated.",
-   "scope":"text.php"
-},
-"hook_menu_local_tasks_alter":{  
-   "prefix":"hook_menu_local_tasks_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_local_tasks_alter().",
-      " */",
-      "function hook_menu_local_tasks_alter(&$data, $route_name) {","  $1","}"
-   ],
-   "description":"Alter tabs and actions displayed on the page before they are rendered.",
-   "scope":"text.php"
-},
-"hook_menu_site_status_alter":{  
-   "prefix":"hook_menu_site_status_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_site_status_alter().",
-      " */",
-      "function hook_menu_site_status_alter(&$menu_site_status, $path) {","  $1","}"
-   ],
-   "description":"Control site status before menu dispatching.",
-   "scope":"text.php"
-},
-"hook_menu_update":{  
-   "prefix":"hook_menu_update",
-   "body":[  
-      "/**",
-      " * Implements hook_menu_update().",
-      " */",
-      "function hook_menu_update($menu) {","  $1","}"
-   ],
-   "description":"Respond to a custom menu update.",
-   "scope":"text.php"
-},
-"hook_modules_disabled":{  
-   "prefix":"hook_modules_disabled",
-   "body":[  
-      "/**",
-      " * Implements hook_modules_disabled().",
-      " */",
-      "function hook_modules_disabled($modules) {","  $1","}"
-   ],
-   "description":"Perform necessary actions after modules are disabled.",
-   "scope":"text.php"
-},
-"hook_modules_enabled":{  
-   "prefix":"hook_modules_enabled",
-   "body":[  
-      "/**",
-      " * Implements hook_modules_enabled().",
-      " */",
-      "function hook_modules_enabled($modules) {","  $1","}"
-   ],
-   "description":"Perform necessary actions after modules are enabled.",
-   "scope":"text.php"
-},
-"hook_modules_installed":{  
-   "prefix":"hook_modules_installed",
-   "body":[  
-      "/**",
-      " * Implements hook_modules_installed().",
-      " */",
-      "function hook_modules_installed($modules) {","  $1","}"
-   ],
-   "description":"Perform necessary actions after modules are installed.",
-   "scope":"text.php"
-},
-"hook_modules_uninstalled":{  
-   "prefix":"hook_modules_uninstalled",
-   "body":[  
-      "/**",
-      " * Implements hook_modules_uninstalled().",
-      " */",
-      "function hook_modules_uninstalled($modules) {","  $1","}"
-   ],
-   "description":"Perform necessary actions after modules are uninstalled.",
-   "scope":"text.php"
-},
-"hook_module_implements_alter":{  
-   "prefix":"hook_module_implements_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_module_implements_alter().",
-      " */",
-      "function hook_module_implements_alter(&$implementations, $hook) {","  $1","}"
-   ],
-   "description":"Alter the registry of modules implementing a hook.",
-   "scope":"text.php"
-},
-"hook_multilingual_settings_changed":{  
-   "prefix":"hook_multilingual_settings_changed",
-   "body":[  
-      "/**",
-      " * Implements hook_multilingual_settings_changed().",
-      " */",
-      "function hook_multilingual_settings_changed()hook_node_access(\\Drupal\\node\\NodeInterface $node, $op, \\Drupal\\Core\\Session\\AccountInterface $account) {","  $1","}"
-   ],
-   "description":"Allow modules to react to language settings changes.",
-   "scope":"text.php"
-},
-"hook_node_access":{  
-   "prefix":"hook_node_access",
-   "body":[  
-      "/**",
-      " * Implements hook_node_access().",
-      " */",
-      "function hook_node_access_records(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
-   ],
-   "description":"Control access to a node.",
-   "scope":"text.php"
-},
-"hook_node_access_records":{  
-   "prefix":"hook_node_access_records",
-   "body":[  
-      "/**",
-      " * Implements hook_node_access_records().",
-      " */",
-      "function hook_node_access_records_alter(&$grants, Drupal\\node\\NodeInterface $node) {","  $1","}"
-   ],
-   "description":"Set permissions for a node to be written to the database.",
-   "scope":"text.php"
-},
-"hook_node_access_records_alter":{  
-   "prefix":"hook_node_access_records_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_node_access_records_alter().",
-      " */",
-      "function hook_node_access_records_alter(&$grants, $node) {","  $1","}"
-   ],
-   "description":"Alter permissions for a node before it is written to the database.",
-   "scope":"text.php"
-},
-"hook_node_delete":{  
-   "prefix":"hook_node_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_node_delete().",
-      " */",
-      "function hook_node_delete($node) {","  $1","}"
-   ],
-   "description":"Respond to node deletion.",
-   "scope":"text.php"
-},
-"hook_node_grants":{  
-   "prefix":"hook_node_grants",
-   "body":[  
-      "/**",
-      " * Implements hook_node_grants().",
-      " */",
-      "function hook_node_grants(\\Drupal\\Core\\Session\\AccountInterface $account, $op) {","  $1","}"
-   ],
-   "description":"Inform the node access system what permissions the user has.",
-   "scope":"text.php"
-},
-"hook_node_grants_alter":{  
-   "prefix":"hook_node_grants_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_node_grants_alter().",
-      " */",
-      "function hook_node_grants_alter(&$grants, \\Drupal\\Core\\Session\\AccountInterface $account, $op) {","  $1","}"
-   ],
-   "description":"Alter user access rules when trying to view, edit or delete a node.",
-   "scope":"text.php"
-},
-"hook_node_info":{  
-   "prefix":"hook_node_info",
-   "body":[  
-      "/**",
-      " * Implements hook_node_info().",
-      " */",
-      "function hook_node_info() {","  $1","}"
-   ],
-   "description":"Define module-provided node types.",
-   "scope":"text.php"
-},
-"hook_node_insert":{  
-   "prefix":"hook_node_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_node_insert().",
-      " */",
-      "function hook_node_insert($node) {","  $1","}"
-   ],
-   "description":"Respond to creation of a new node.",
-   "scope":"text.php"
-},
-"hook_node_load":{  
-   "prefix":"hook_node_load",
-   "body":[  
-      "/**",
-      " * Implements hook_node_load().",
-      " */",
-      "function hook_node_load($nodes, $types) {","  $1","}"
-   ],
-   "description":"Act on arbitrary nodes being loaded from the database.",
-   "scope":"text.php"
-},
-"hook_node_operations":{  
-   "prefix":"hook_node_operations",
-   "body":[  
-      "/**",
-      " * Implements hook_node_operations().",
-      " */",
-      "function hook_node_operations() {","  $1","}"
-   ],
-   "description":"Add mass node operations.",
-   "scope":"text.php"
-},
-"hook_node_prepare":{  
-   "prefix":"hook_node_prepare",
-   "body":[  
-      "/**",
-      " * Implements hook_node_prepare().",
-      " */",
-      "function hook_node_prepare($node) {","  $1","}"
-   ],
-   "description":"Act on a node object about to be shown on the add/edit form.",
-   "scope":"text.php"
-},
-"hook_node_presave":{  
-   "prefix":"hook_node_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_node_presave().",
-      " */",
-      "function hook_node_presave($node) {","  $1","}"
-   ],
-   "description":"Act on a node being inserted or updated.",
-   "scope":"text.php"
-},
-"hook_node_revision_delete":{  
-   "prefix":"hook_node_revision_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_node_revision_delete().",
-      " */",
-      "function hook_node_revision_delete($node) {","  $1","}"
-   ],
-   "description":"Respond to deletion of a node revision.",
-   "scope":"text.php"
-},
-"hook_node_search_result":{  
-   "prefix":"hook_node_search_result",
-   "body":[  
-      "/**",
-      " * Implements hook_node_search_result().",
-      " */",
-      "function hook_node_search_result(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
-   ],
-   "description":"Act on a node being displayed as a search result.",
-   "scope":"text.php"
-},
-"hook_node_submit":{  
-   "prefix":"hook_node_submit",
-   "body":[  
-      "/**",
-      " * Implements hook_node_submit().",
-      " */",
-      "function hook_node_submit($node, $form, &$form_state) {","  $1","}"
-   ],
-   "description":"Act on a node after validated form values have been copied to it.",
-   "scope":"text.php"
-},
-"hook_node_type_delete":{  
-   "prefix":"hook_node_type_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_node_type_delete().",
-      " */",
-      "function hook_node_type_delete($info) {","  $1","}"
-   ],
-   "description":"Respond to node type deletion.",
-   "scope":"text.php"
-},
-"hook_node_type_insert":{  
-   "prefix":"hook_node_type_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_node_type_insert().",
-      " */",
-      "function hook_node_type_insert($info) {","  $1","}"
-   ],
-   "description":"Respond to node type creation.",
-   "scope":"text.php"
-},
-"hook_node_type_update":{  
-   "prefix":"hook_node_type_update",
-   "body":[  
-      "/**",
-      " * Implements hook_node_type_update().",
-      " */",
-      "function hook_node_type_update($info) {","  $1","}"
-   ],
-   "description":"Respond to node type updates.",
-   "scope":"text.php"
-},
-"hook_node_update":{  
-   "prefix":"hook_node_update",
-   "body":[  
-      "/**",
-      " * Implements hook_node_update().",
-      " */",
-      "function hook_node_update($node) {","  $1","}"
-   ],
-   "description":"Respond to updates to a node.",
-   "scope":"text.php"
-},
-"hook_node_update_index":{  
-   "prefix":"hook_node_update_index",
-   "body":[  
-      "/**",
-      " * Implements hook_node_update_index().",
-      " */",
-      "function hook_node_update_index(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
-   ],
-   "description":"Act on a node being indexed for searching.",
-   "scope":"text.php"
-},
-"hook_node_validate":{  
-   "prefix":"hook_node_validate",
-   "body":[  
-      "/**",
-      " * Implements hook_node_validate().",
-      " */",
-      "function hook_node_validate($node, $form, &$form_state) {","  $1","}"
-   ],
-   "description":"Perform node validation before a node is created or updated.",
-   "scope":"text.php"
-},
-"hook_node_view":{  
-   "prefix":"hook_node_view",
-   "body":[  
-      "/**",
-      " * Implements hook_node_view().",
-      " */",
-      "function hook_node_view($node, $view_mode, $langcode) {","  $1","}"
-   ],
-   "description":"Act on a node that is being assembled before rendering.",
-   "scope":"text.php"
-},
-"hook_node_view_alter":{  
-   "prefix":"hook_node_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_node_view_alter().",
-      " */",
-      "function hook_node_view_alter(&$build) {","  $1","}"
-   ],
-   "description":"Alter the results of node_view().",
-   "scope":"text.php"
-},
-"hook_openid":{  
-   "prefix":"hook_openid",
-   "body":[  
-      "/**",
-      " * Implements hook_openid().",
-      " */",
-      "function hook_openid($op, $request) {","  $1","}"
-   ],
-   "description":"Allow modules to modify the OpenID request parameters.",
-   "scope":"text.php"
-},
-"hook_openid_discovery_method_info":{  
-   "prefix":"hook_openid_discovery_method_info",
-   "body":[  
-      "/**",
-      " * Implements hook_openid_discovery_method_info().",
-      " */",
-      "function hook_openid_discovery_method_info() {","  $1","}"
-   ],
-   "description":"Allow modules to declare OpenID discovery methods.",
-   "scope":"text.php"
-},
-"hook_openid_discovery_method_info_alter":{  
-   "prefix":"hook_openid_discovery_method_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_openid_discovery_method_info_alter().",
-      " */",
-      "function hook_openid_discovery_method_info_alter(&$methods) {","  $1","}"
-   ],
-   "description":"Allow modules to alter discovery methods.",
-   "scope":"text.php"
-},
-"hook_openid_normalization_method_info":{  
-   "prefix":"hook_openid_normalization_method_info",
-   "body":[  
-      "/**",
-      " * Implements hook_openid_normalization_method_info().",
-      " */",
-      "function hook_openid_normalization_method_info() {","  $1","}"
-   ],
-   "description":"Allow modules to declare OpenID normalization methods.",
-   "scope":"text.php"
-},
-"hook_openid_normalization_method_info_alter":{  
-   "prefix":"hook_openid_normalization_method_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_openid_normalization_method_info_alter().",
-      " */",
-      "function hook_openid_normalization_method_info_alter(&$methods) {","  $1","}"
-   ],
-   "description":"Allow modules to alter normalization methods.",
-   "scope":"text.php"
-},
-"hook_openid_response":{  
-   "prefix":"hook_openid_response",
-   "body":[  
-      "/**",
-      " * Implements hook_openid_response().",
-      " */",
-      "function hook_openid_response($response, $account) {","  $1","}"
-   ],
-   "description":"Allow modules to act upon a successful OpenID login.",
-   "scope":"text.php"
-},
-"hook_overlay_child_initialize":{  
-   "prefix":"hook_overlay_child_initialize",
-   "body":[  
-      "/**",
-      " * Implements hook_overlay_child_initialize().",
-      " */",
-      "function hook_overlay_child_initialize() {","  $1","}"
-   ],
-   "description":"Allow modules to act when an overlay child window is initialized.",
-   "scope":"text.php"
-},
-"hook_overlay_parent_initialize":{  
-   "prefix":"hook_overlay_parent_initialize",
-   "body":[  
-      "/**",
-      " * Implements hook_overlay_parent_initialize().",
-      " */",
-      "function hook_overlay_parent_initialize() {","  $1","}"
-   ],
-   "description":"Allow modules to act when an overlay parent window is initialized.",
-   "scope":"text.php"
-},
-"hook_page_alter":{  
-   "prefix":"hook_page_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_page_alter().",
-      " */",
-      "function hook_page_alter(&$page) {","  $1","}"
-   ],
-   "description":"Perform alterations before a page is rendered.",
-   "scope":"text.php"
-},
-"hook_page_build":{  
-   "prefix":"hook_page_build",
-   "body":[  
-      "/**",
-      " * Implements hook_page_build().",
-      " */",
-      "function hook_page_build(&$page) {","  $1","}"
-   ],
-   "description":"Add elements to a page before it is rendered.",
-   "scope":"text.php"
-},
-"hook_page_delivery_callback_alter":{  
-   "prefix":"hook_page_delivery_callback_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_page_delivery_callback_alter().",
-      " */",
-      "function hook_page_delivery_callback_alter(&$callback) {","  $1","}"
-   ],
-   "description":"Alters the delivery callback used to send the result of the page callback to the browser.",
-   "scope":"text.php"
-},
-"hook_path_delete":{  
-   "prefix":"hook_path_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_path_delete().",
-      " */",
-      "function hook_path_delete($path) {","  $1","}"
-   ],
-   "description":"Respond to a path being deleted.",
-   "scope":"text.php"
-},
-"hook_path_insert":{  
-   "prefix":"hook_path_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_path_insert().",
-      " */",
-      "function hook_path_insert($path) {","  $1","}"
-   ],
-   "description":"Respond to a path being inserted.",
-   "scope":"text.php"
-},
-"hook_path_update":{  
-   "prefix":"hook_path_update",
-   "body":[  
-      "/**",
-      " * Implements hook_path_update().",
-      " */",
-      "function hook_path_update($path) {","  $1","}"
-   ],
-   "description":"Respond to a path being updated.",
-   "scope":"text.php"
-},
-"hook_permission":{  
-   "prefix":"hook_permission",
-   "body":[  
-      "/**",
-      " * Implements hook_permission().",
-      " */",
-      "function hook_permission() {","  $1","}"
-   ],
-   "description":"Define user permissions.",
-   "scope":"text.php"
-},
-"hook_prepare":{  
-   "prefix":"hook_prepare",
-   "body":[  
-      "/**",
-      " * Implements hook_prepare().",
-      " */",
-      "function hook_prepare($node) {","  $1","}"
-   ],
-   "description":"Act on a node object about to be shown on the add/edit form.",
-   "scope":"text.php"
-},
-"hook_query_alter":{  
-   "prefix":"hook_query_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_query_alter().",
-      " */",
-      "function hook_query_alter(Drupal\\Core\\Database\\Query\\AlterableInterface $query) {","  $1","}"
-   ],
-   "description":"Perform alterations to a structured query.",
-   "scope":"text.php"
-},
-"hook_query_TAG_alter":{  
-   "prefix":"hook_query_TAG_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_query_TAG_alter().",
-      " */",
-      "function hook_query_TAG_alter(Drupal\\Core\\Database\\Query\\AlterableInterface $query) {","  $1","}"
-   ],
-   "description":"Perform alterations to a structured query for a given tag.",
-   "scope":"text.php"
-},
-"hook_ranking":{  
-   "prefix":"hook_ranking",
-   "body":[  
-      "/**",
-      " * Implements hook_ranking().",
-      " */",
-      "function hook_ranking()hook_rdf_mapping() {","  $1","}"
-   ],
-   "description":"Provide additional methods of scoring for core search results for nodes.",
-   "scope":"text.php"
-},
-"hook_rdf_mapping":{  
-   "prefix":"hook_rdf_mapping",
-   "body":[  
-      "/**",
-      " * Implements hook_rdf_mapping().",
-      " */",
-      "function hook_rdf_namespaces() {","  $1","}"
-   ],
-   "description":"Allow modules to define RDF mappings for field bundles.",
-   "scope":"text.php"
-},
-"hook_rdf_namespaces":{  
-   "prefix":"hook_rdf_namespaces",
-   "body":[  
-      "/**",
-      " * Implements hook_rdf_namespaces().",
-      " */",
-      "function hook_rdf_namespaces() {","  $1","}"
-   ],
-   "description":"Allow modules to define namespaces for RDF mappings.",
-   "scope":"text.php"
-},
-"hook_registry_files_alter":{  
-   "prefix":"hook_registry_files_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_registry_files_alter().",
-      " */",
-      "function hook_registry_files_alter(&$files, $modules) {","  $1","}"
-   ],
-   "description":"Perform necessary alterations to the list of files parsed by the registry.",
-   "scope":"text.php"
-},
-"hook_requirements":{  
-   "prefix":"hook_requirements",
-   "body":[  
-      "/**",
-      " * Implements hook_requirements().",
-      " */",
-      "function hook_requirements($phase) {","  $1","}"
-   ],
-   "description":"Check installation requirements and do status reporting.",
-   "scope":"text.php"
-},
-"hook_schema":{  
-   "prefix":"hook_schema",
-   "body":[  
-      "/**",
-      " * Implements hook_schema().",
-      " */",
-      "function hook_schema() {","  $1","}"
-   ],
-   "description":"Define the current version of the database schema.",
-   "scope":"text.php"
-},
-"hook_schema_alter":{  
-   "prefix":"hook_schema_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_schema_alter().",
-      " */",
-      "function hook_schema_alter(&$schema) {","  $1","}"
-   ],
-   "description":"Perform alterations to existing database schemas.",
-   "scope":"text.php"
-},
-"hook_search_access":{  
-   "prefix":"hook_search_access",
-   "body":[  
-      "/**",
-      " * Implements hook_search_access().",
-      " */",
-      "function hook_search_access() {","  $1","}"
-   ],
-   "description":"Define access to a custom search routine.",
-   "scope":"text.php"
-},
-"hook_search_admin":{  
-   "prefix":"hook_search_admin",
-   "body":[  
-      "/**",
-      " * Implements hook_search_admin().",
-      " */",
-      "function hook_search_admin() {","  $1","}"
-   ],
-   "description":"Add elements to the search settings form.",
-   "scope":"text.php"
-},
-"hook_search_execute":{  
-   "prefix":"hook_search_execute",
-   "body":[  
-      "/**",
-      " * Implements hook_search_execute().",
-      " */",
-      "function hook_search_execute($keys = NULL, $conditions = NULL) {","  $1","}"
-   ],
-   "description":"Execute a search for a set of key words.",
-   "scope":"text.php"
-},
-"hook_search_info":{  
-   "prefix":"hook_search_info",
-   "body":[  
-      "/**",
-      " * Implements hook_search_info().",
-      " */",
-      "function hook_search_info() {","  $1","}"
-   ],
-   "description":"Define a custom search type.",
-   "scope":"text.php"
-},
-"hook_search_page":{  
-   "prefix":"hook_search_page",
-   "body":[  
-      "/**",
-      " * Implements hook_search_page().",
-      " */",
-      "function hook_search_page($results) {","  $1","}"
-   ],
-   "description":"Override the rendering of search results.",
-   "scope":"text.php"
-},
-"hook_search_preprocess":{  
-   "prefix":"hook_search_preprocess",
-   "body":[  
-      "/**",
-      " * Implements hook_search_preprocess().",
-      " */",
-      "function hook_search_preprocess($text, $langcode = NULL) {","  $1","}"
-   ],
-   "description":"Preprocess text for search.",
-   "scope":"text.php"
-},
-"hook_search_reset":{  
-   "prefix":"hook_search_reset",
-   "body":[  
-      "/**",
-      " * Implements hook_search_reset().",
-      " */",
-      "function hook_search_reset() {","  $1","}"
-   ],
-   "description":"Take action when the search index is going to be rebuilt.",
-   "scope":"text.php"
-},
-"hook_search_status":{  
-   "prefix":"hook_search_status",
-   "body":[  
-      "/**",
-      " * Implements hook_search_status().",
-      " */",
-      "function hook_search_status() {","  $1","}"
-   ],
-   "description":"Report the status of indexing.",
-   "scope":"text.php"
-},
-"hook_shortcut_default_set":{  
-   "prefix":"hook_shortcut_default_set",
-   "body":[  
-      "/**",
-      " * Implements hook_shortcut_default_set().",
-      " */",
-      "function hook_shortcut_default_set($account) {","  $1","}"
-   ],
-   "description":"Return the name of a default shortcut set for the provided user account.",
-   "scope":"text.php"
-},
-"hook_simpletest_alter":{  
-   "prefix":"hook_simpletest_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_simpletest_alter().",
-      " */",
-      "function hook_simpletest_alter(&$groups)hook_stream_wrappers() {","  $1","}"
-   ],
-   "description":"Alter the list of tests.",
-   "scope":"text.php"
-},
-"hook_stream_wrappers":{  
-   "prefix":"hook_stream_wrappers",
-   "body":[  
-      "/**",
-      " * Implements hook_stream_wrappers().",
-      " */",
-      "function hook_stream_wrappers_alter(&$wrappers) {","  $1","}"
-   ],
-   "description":"Registers PHP stream wrapper implementations associated with a module.",
-   "scope":"text.php"
-},
-"hook_stream_wrappers_alter":{  
-   "prefix":"hook_stream_wrappers_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_stream_wrappers_alter().",
-      " */",
-      "function hook_system_info_alter(array &$info, \\Drupal\\Core\\Extension\\Extension $file, $type) {","  $1","}"
-   ],
-   "description":"Alters the list of PHP stream wrapper implementations.",
-   "scope":"text.php"
-},
-"hook_system_info_alter":{  
-   "prefix":"hook_system_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_system_info_alter().",
-      " */",
-      "function hook_system_themes_page_alter(&$theme_groups) {","  $1","}"
-   ],
-   "description":"Alter the information parsed from module and theme .info files",
-   "scope":"text.php"
-},
-"hook_system_themes_page_alter":{  
-   "prefix":"hook_system_themes_page_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_system_themes_page_alter().",
-      " */",
-      "function hook_system_themes_page_alter(&$theme_groups) {","  $1","}"
-   ],
-   "description":"Alters theme operation links.",
-   "scope":"text.php"
-},
-"hook_system_theme_info":{  
-   "prefix":"hook_system_theme_info",
-   "body":[  
-      "/**",
-      " * Implements hook_system_theme_info().",
-      " */",
-      "function hook_system_theme_info() {","  $1","}"
-   ],
-   "description":"Return additional themes provided by modules.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_delete":{  
-   "prefix":"hook_taxonomy_term_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_delete().",
-      " */",
-      "function hook_taxonomy_term_delete($term) {","  $1","}"
-   ],
-   "description":"Respond to the deletion of taxonomy terms.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_insert":{  
-   "prefix":"hook_taxonomy_term_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_insert().",
-      " */",
-      "function hook_taxonomy_term_insert($term) {","  $1","}"
-   ],
-   "description":"Act on taxonomy terms when inserted.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_load":{  
-   "prefix":"hook_taxonomy_term_load",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_load().",
-      " */",
-      "function hook_taxonomy_term_load($terms) {","  $1","}"
-   ],
-   "description":"Act on taxonomy terms when loaded.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_presave":{  
-   "prefix":"hook_taxonomy_term_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_presave().",
-      " */",
-      "function hook_taxonomy_term_presave($term) {","  $1","}"
-   ],
-   "description":"Act on taxonomy terms before they are saved.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_update":{  
-   "prefix":"hook_taxonomy_term_update",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_update().",
-      " */",
-      "function hook_taxonomy_term_update($term) {","  $1","}"
-   ],
-   "description":"Act on taxonomy terms when updated.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_view":{  
-   "prefix":"hook_taxonomy_term_view",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_view().",
-      " */",
-      "function hook_taxonomy_term_view($term, $view_mode, $langcode) {","  $1","}"
-   ],
-   "description":"Act on a taxonomy term that is being assembled before rendering.",
-   "scope":"text.php"
-},
-"hook_taxonomy_term_view_alter":{  
-   "prefix":"hook_taxonomy_term_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_term_view_alter().",
-      " */",
-      "function hook_taxonomy_term_view_alter(&$build) {","  $1","}"
-   ],
-   "description":"Alter the results of taxonomy_term_view().",
-   "scope":"text.php"
-},
-"hook_taxonomy_vocabulary_delete":{  
-   "prefix":"hook_taxonomy_vocabulary_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_vocabulary_delete().",
-      " */",
-      "function hook_taxonomy_vocabulary_delete($vocabulary) {","  $1","}"
-   ],
-   "description":"Respond to the deletion of taxonomy vocabularies.",
-   "scope":"text.php"
-},
-"hook_taxonomy_vocabulary_insert":{  
-   "prefix":"hook_taxonomy_vocabulary_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_vocabulary_insert().",
-      " */",
-      "function hook_taxonomy_vocabulary_insert($vocabulary) {","  $1","}"
-   ],
-   "description":"Act on taxonomy vocabularies when inserted.",
-   "scope":"text.php"
-},
-"hook_taxonomy_vocabulary_load":{  
-   "prefix":"hook_taxonomy_vocabulary_load",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_vocabulary_load().",
-      " */",
-      "function hook_taxonomy_vocabulary_load($vocabularies) {","  $1","}"
-   ],
-   "description":"Act on taxonomy vocabularies when loaded.",
-   "scope":"text.php"
-},
-"hook_taxonomy_vocabulary_presave":{  
-   "prefix":"hook_taxonomy_vocabulary_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_vocabulary_presave().",
-      " */",
-      "function hook_taxonomy_vocabulary_presave($vocabulary) {","  $1","}"
-   ],
-   "description":"Act on taxonomy vocabularies before they are saved.",
-   "scope":"text.php"
-},
-"hook_taxonomy_vocabulary_update":{  
-   "prefix":"hook_taxonomy_vocabulary_update",
-   "body":[  
-      "/**",
-      " * Implements hook_taxonomy_vocabulary_update().",
-      " */",
-      "function hook_taxonomy_vocabulary_update($vocabulary) {","  $1","}"
-   ],
-   "description":"Act on taxonomy vocabularies when updated.",
-   "scope":"text.php"
-},
-"hook_test_finished":{  
-   "prefix":"hook_test_finished",
-   "body":[  
-      "/**",
-      " * Implements hook_test_finished().",
-      " */",
-      "function hook_test_finished($results) {","  $1","}"
-   ],
-   "description":"An individual test has finished.",
-   "scope":"text.php"
-},
-"hook_test_group_finished":{  
-   "prefix":"hook_test_group_finished",
-   "body":[  
-      "/**",
-      " * Implements hook_test_group_finished().",
-      " */",
-      "function hook_test_group_finished() {","  $1","}"
-   ],
-   "description":"A test group has finished.",
-   "scope":"text.php"
-},
-"hook_test_group_started":{  
-   "prefix":"hook_test_group_started",
-   "body":[  
-      "/**",
-      " * Implements hook_test_group_started().",
-      " */",
-      "function hook_test_group_started() {","  $1","}"
-   ],
-   "description":"A test group has started.",
-   "scope":"text.php"
-},
-"hook_theme":{  
-   "prefix":"hook_theme",
-   "body":[  
-      "/**",
-      " * Implements hook_theme().",
-      " */",
-      "function hook_theme($existing, $type, $theme, $path) {","  $1","}"
-   ],
-   "description":"Register a module (or theme's) theme implementations.",
-   "scope":"text.php"
-},
-"hook_theme_registry_alter":{  
-   "prefix":"hook_theme_registry_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_theme_registry_alter().",
-      " */",
-      "function hook_theme_registry_alter(&$theme_registry) {","  $1","}"
-   ],
-   "description":"Alter the theme registry information returned from hook_theme().",
-   "scope":"text.php"
-},
-"hook_tokens":{  
-   "prefix":"hook_tokens",
-   "body":[  
-      "/**",
-      " * Implements hook_tokens().",
-      " */",
-      "function hook_tokens($type, $tokens, array $data, array $options, \\Drupal\\Core\\Render\\BubbleableMetadata $bubbleable_metadata) {","  $1","}"
-   ],
-   "description":"Provide replacement values for placeholder tokens.",
-   "scope":"text.php"
-},
-"hook_tokens_alter":{  
-   "prefix":"hook_tokens_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_tokens_alter().",
-      " */",
-      "function hook_tokens_alter(array &$replacements, array $context, \\Drupal\\Core\\Render\\BubbleableMetadata $bubbleable_metadata) {","  $1","}"
-   ],
-   "description":"Alter replacement values for placeholder tokens.",
-   "scope":"text.php"
-},
-"hook_token_info":{  
-   "prefix":"hook_token_info",
-   "body":[  
-      "/**",
-      " * Implements hook_token_info().",
-      " */",
-      "function hook_token_info() {","  $1","}"
-   ],
-   "description":"Provide information about available placeholder tokens and token types.",
-   "scope":"text.php"
-},
-"hook_token_info_alter":{  
-   "prefix":"hook_token_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_token_info_alter().",
-      " */",
-      "function hook_token_info_alter(&$data) {","  $1","}"
-   ],
-   "description":"Alter the metadata about available placeholder tokens and token types.",
-   "scope":"text.php"
-},
-"hook_translated_menu_link_alter":{  
-   "prefix":"hook_translated_menu_link_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_translated_menu_link_alter().",
-      " */",
-      "function hook_translated_menu_link_alter(&$item, $map) {","  $1","}"
-   ],
-   "description":"Alter a menu link after it has been translated and before it is rendered.",
-   "scope":"text.php"
-},
-"hook_trigger_info":{  
-   "prefix":"hook_trigger_info",
-   "body":[  
-      "/**",
-      " * Implements hook_trigger_info().",
-      " */",
-      "function Not found: hook_trigger_info {","  $1","}"
-   ],
-   "description":"Declare triggers (events) for users to assign actions to.",
-   "scope":"text.php"
-},
-"hook_trigger_info_alter":{  
-   "prefix":"hook_trigger_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_trigger_info_alter().",
-      " */",
-      "function Not found: hook_trigger_info_alter {","  $1","}"
-   ],
-   "description":"Alter triggers declared by hook_trigger_info().",
-   "scope":"text.php"
-},
-"hook_uninstall":{  
-   "prefix":"hook_uninstall",
-   "body":[  
-      "/**",
-      " * Implements hook_uninstall().",
-      " */",
-      "function hook_uninstall() {","  $1","}"
-   ],
-   "description":"Remove any information that the module sets.",
-   "scope":"text.php"
-},
-"hook_update":{  
-   "prefix":"hook_update",
-   "body":[  
-      "/**",
-      " * Implements hook_update().",
-      " */",
-      "function hook_update($node) {","  $1","}"
-   ],
-   "description":"Respond to updates to a node.",
-   "scope":"text.php"
-},
-"hook_updater_info":{  
-   "prefix":"hook_updater_info",
-   "body":[  
-      "/**",
-      " * Implements hook_updater_info().",
-      " */",
-      "function hook_updater_info() {","  $1","}"
-   ],
-   "description":"Provide information on Updaters (classes that can update Drupal).",
-   "scope":"text.php"
-},
-"hook_updater_info_alter":{  
-   "prefix":"hook_updater_info_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_updater_info_alter().",
-      " */",
-      "function hook_updater_info_alter(&$updaters) {","  $1","}"
-   ],
-   "description":"Alter the Updater information array.",
-   "scope":"text.php"
-},
-"hook_update_dependencies":{  
-   "prefix":"hook_update_dependencies",
-   "body":[  
-      "/**",
-      " * Implements hook_update_dependencies().",
-      " */",
-      "function hook_update_dependencies() {","  $1","}"
-   ],
-   "description":"Return an array of information about module update dependencies.",
-   "scope":"text.php"
-},
-"hook_update_index":{  
-   "prefix":"hook_update_index",
-   "body":[  
-      "/**",
-      " * Implements hook_update_index().",
-      " */",
-      "function hook_update_index() {","  $1","}"
-   ],
-   "description":"Update the search index for this module.",
-   "scope":"text.php"
-},
-"hook_update_last_removed":{  
-   "prefix":"hook_update_last_removed",
-   "body":[  
-      "/**",
-      " * Implements hook_update_last_removed().",
-      " */",
-      "function hook_update_last_removed() {","  $1","}"
-   ],
-   "description":"Return a number which is no longer available as hook_update_N().",
-   "scope":"text.php"
-},
-"hook_update_N":{  
-   "prefix":"hook_update_N",
-   "body":[  
-      "/**",
-      " * Implements hook_update_N().",
-      " */",
-      "function hook_update_N(&$sandbox) {","  $1","}"
-   ],
-   "description":"Perform a single update.",
-   "scope":"text.php"
-},
-"hook_update_projects_alter":{  
-   "prefix":"hook_update_projects_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_update_projects_alter().",
-      " */",
-      "function hook_update_projects_alter(&$projects) {","  $1","}"
-   ],
-   "description":"Alter the list of projects before fetching data and comparing versions.",
-   "scope":"text.php"
-},
-"hook_update_status_alter":{  
-   "prefix":"hook_update_status_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_update_status_alter().",
-      " */",
-      "function hook_update_status_alter(&$projects) {","  $1","}"
-   ],
-   "description":"Alter the information about available updates for projects.",
-   "scope":"text.php"
-},
-"hook_url_inbound_alter":{  
-   "prefix":"hook_url_inbound_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_url_inbound_alter().",
-      " */",
-      "function hook_url_inbound_alter(&$path, $original_path, $path_language) {","  $1","}"
-   ],
-   "description":"Alters inbound URL requests.",
-   "scope":"text.php"
-},
-"hook_url_outbound_alter":{  
-   "prefix":"hook_url_outbound_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_url_outbound_alter().",
-      " */",
-      "function hook_url_outbound_alter(&$path, &$options, $original_path) {","  $1","}"
-   ],
-   "description":"Alters outbound URLs.",
-   "scope":"text.php"
-},
-"hook_username_alter":{  
-   "prefix":"hook_username_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_username_alter().",
-      " */",
-      "function hook_username_alter(&$name, $account) {","  $1","}"
-   ],
-   "description":"Alter the username that is displayed for a user.",
-   "scope":"text.php"
-},
-"hook_user_cancel":{  
-   "prefix":"hook_user_cancel",
-   "body":[  
-      "/**",
-      " * Implements hook_user_cancel().",
-      " */",
-      "function hook_user_cancel($edit, $account, $method) {","  $1","}"
-   ],
-   "description":"Act on user account cancellations.",
-   "scope":"text.php"
-},
-"hook_user_cancel_methods_alter":{  
-   "prefix":"hook_user_cancel_methods_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_user_cancel_methods_alter().",
-      " */",
-      "function hook_user_cancel_methods_alter(&$methods) {","  $1","}"
-   ],
-   "description":"Modify account cancellation methods.",
-   "scope":"text.php"
-},
-"hook_user_categories":{  
-   "prefix":"hook_user_categories",
-   "body":[  
-      "/**",
-      " * Implements hook_user_categories().",
-      " */",
-      "function hook_user_categories() {","  $1","}"
-   ],
-   "description":"Define a list of user settings or profile information categories.",
-   "scope":"text.php"
-},
-"hook_user_delete":{  
-   "prefix":"hook_user_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_user_delete().",
-      " */",
-      "function hook_user_delete($account) {","  $1","}"
-   ],
-   "description":"Respond to user deletion.",
-   "scope":"text.php"
-},
-"hook_user_insert":{  
-   "prefix":"hook_user_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_user_insert().",
-      " */",
-      "function hook_user_insert(&$edit, $account, $category) {","  $1","}"
-   ],
-   "description":"A user account was created.",
-   "scope":"text.php"
-},
-"hook_user_load":{  
-   "prefix":"hook_user_load",
-   "body":[  
-      "/**",
-      " * Implements hook_user_load().",
-      " */",
-      "function hook_user_load($users) {","  $1","}"
-   ],
-   "description":"Act on user objects when loaded from the database.",
-   "scope":"text.php"
-},
-"hook_user_login":{  
-   "prefix":"hook_user_login",
-   "body":[  
-      "/**",
-      " * Implements hook_user_login().",
-      " */",
-      "function hook_user_login($account) {","  $1","}"
-   ],
-   "description":"The user just logged in.",
-   "scope":"text.php"
-},
-"hook_user_logout":{  
-   "prefix":"hook_user_logout",
-   "body":[  
-      "/**",
-      " * Implements hook_user_logout().",
-      " */",
-      "function hook_user_logout($account) {","  $1","}"
-   ],
-   "description":"The user just logged out.",
-   "scope":"text.php"
-},
-"hook_user_operations":{  
-   "prefix":"hook_user_operations",
-   "body":[  
-      "/**",
-      " * Implements hook_user_operations().",
-      " */",
-      "function hook_user_operations() {","  $1","}"
-   ],
-   "description":"Add mass user operations.",
-   "scope":"text.php"
-},
-"hook_user_presave":{  
-   "prefix":"hook_user_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_user_presave().",
-      " */",
-      "function hook_user_presave(&$edit, $account, $category) {","  $1","}"
-   ],
-   "description":"A user account is about to be created or updated.",
-   "scope":"text.php"
-},
-"hook_user_role_delete":{  
-   "prefix":"hook_user_role_delete",
-   "body":[  
-      "/**",
-      " * Implements hook_user_role_delete().",
-      " */",
-      "function hook_user_role_delete($role) {","  $1","}"
-   ],
-   "description":"Respond to user role deletion.",
-   "scope":"text.php"
-},
-"hook_user_role_insert":{  
-   "prefix":"hook_user_role_insert",
-   "body":[  
-      "/**",
-      " * Implements hook_user_role_insert().",
-      " */",
-      "function hook_user_role_insert($role) {","  $1","}"
-   ],
-   "description":"Respond to creation of a new user role.",
-   "scope":"text.php"
-},
-"hook_user_role_presave":{  
-   "prefix":"hook_user_role_presave",
-   "body":[  
-      "/**",
-      " * Implements hook_user_role_presave().",
-      " */",
-      "function hook_user_role_presave($role) {","  $1","}"
-   ],
-   "description":"Act on a user role being inserted or updated.",
-   "scope":"text.php"
-},
-"hook_user_role_update":{  
-   "prefix":"hook_user_role_update",
-   "body":[  
-      "/**",
-      " * Implements hook_user_role_update().",
-      " */",
-      "function hook_user_role_update($role) {","  $1","}"
-   ],
-   "description":"Respond to updates to a user role.",
-   "scope":"text.php"
-},
-"hook_user_update":{  
-   "prefix":"hook_user_update",
-   "body":[  
-      "/**",
-      " * Implements hook_user_update().",
-      " */",
-      "function hook_user_update(&$edit, $account, $category) {","  $1","}"
-   ],
-   "description":"A user account was updated.",
-   "scope":"text.php"
-},
-"hook_user_view":{  
-   "prefix":"hook_user_view",
-   "body":[  
-      "/**",
-      " * Implements hook_user_view().",
-      " */",
-      "function hook_user_view($account, $view_mode, $langcode) {","  $1","}"
-   ],
-   "description":"The user's account information is being displayed.",
-   "scope":"text.php"
-},
-"hook_user_view_alter":{  
-   "prefix":"hook_user_view_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_user_view_alter().",
-      " */",
-      "function hook_user_view_alter(&$build) {","  $1","}"
-   ],
-   "description":"The user was built; the module may modify the structured content.",
-   "scope":"text.php"
-},
-"hook_validate":{  
-   "prefix":"hook_validate",
-   "body":[  
-      "/**",
-      " * Implements hook_validate().",
-      " */",
-      "function hook_validate($node, $form, &$form_state) {","  $1","}"
-   ],
-   "description":"Perform node validation before a node is created or updated.",
-   "scope":"text.php"
-},
-"hook_verify_update_archive":{  
-   "prefix":"hook_verify_update_archive",
-   "body":[  
-      "/**",
-      " * Implements hook_verify_update_archive().",
-      " */",
-      "function hook_verify_update_archive($project, $archive_file, $directory) {","  $1","}"
-   ],
-   "description":"Verify an archive after it has been downloaded and extracted.",
-   "scope":"text.php"
-},
-"hook_view":{  
-   "prefix":"hook_view",
-   "body":[  
-      "/**",
-      " * Implements hook_view().",
-      " */",
-      "function hook_view($node, $view_mode, $langcode = NULL) {","  $1","}"
-   ],
-   "description":"Display a node.",
-   "scope":"text.php"
-},
-"hook_watchdog":{  
-   "prefix":"hook_watchdog",
-   "body":[  
-      "/**",
-      " * Implements hook_watchdog().",
-      " */",
-      "function hook_watchdog(array $log_entry) {","  $1","}"
-   ],
-   "description":"Log an event message.",
-   "scope":"text.php"
-},
-"hook_xmlrpc":{  
-   "prefix":"hook_xmlrpc",
-   "body":[  
-      "/**",
-      " * Implements hook_xmlrpc().",
-      " */",
-      "function hook_xmlrpc() {","  $1","}"
-   ],
-   "description":"Register XML-RPC callbacks.",
-   "scope":"text.php"
-},
-"hook_xmlrpc_alter":{  
-   "prefix":"hook_xmlrpc_alter",
-   "body":[  
-      "/**",
-      " * Implements hook_xmlrpc_alter().",
-      " */",
-      "function hook_xmlrpc_alter(&$methods)module_hook($module, $hook) {","  $1","}"
-   ],
-   "description":"Alters the definition of XML-RPC methods before they are called.",
-   "scope":"text.php"
-},
-"module_hook":{  
-   "prefix":"module_hook",
-   "body":[  
-      "/**",
-      " * Implements module_hook().",
-      " */",
-      "function module_hook_info() {","  $1","}"
-   ],
-   "description":"Determines whether a module implements a hook.",
-   "scope":"text.php"
-},
-"module_hook_info":{  
-   "prefix":"module_hook_info",
-   "body":[  
-      "/**",
-      " * Implements module_hook_info().",
-      " */",
-      "function module_hook_info() {","  $1","}"
-   ],
-   "description":"Retrieves a list of hooks that are declared through hook_hook_info().",
-   "scope":"text.php"
-},
-"module_implements":{  
-   "prefix":"module_implements",
-   "body":[  
-      "/**",
-      " * Implements module_implements().",
-      " */",
-      "function module_implements($hook) {","  $1","}"
-   ],
-   "description":"Determines which modules are implementing a hook.",
-   "scope":"text.php"
-},
-"module_implements_write_cache":{  
-   "prefix":"module_implements_write_cache",
-   "body":[  
-      "/**",
-      " * Implements module_implements_write_cache().",
-      " */",
-      "function module_implements_write_cache() {","  $1","}"
-   ],
-   "description":"Writes the hook implementation cache.",
-   "scope":"text.php"
-},
-"module_invoke":{  
-   "prefix":"module_invoke",
-   "body":[  
-      "/**",
-      " * Implements module_invoke().",
-      " */",
-      "function module_invoke() {","  $1","}"
-   ],
-   "description":"Invokes a hook in a particular module.",
-   "scope":"text.php"
-},
-"module_invoke_all":{  
-   "prefix":"module_invoke_all",
-   "body":[  
-      "/**",
-      " * Implements module_invoke_all().",
-      " */",
-      "function module_invoke_all() {","  $1","}"
-   ],
-   "description":"Invokes a hook in all enabled modules that implement it.",
-   "scope":"text.php"
-}
+{
+  "hook_actions_delete": {
+    "prefix": "hook_actions_delete",
+    "body": [
+        "/**",
+        " * Implements hook_actions_delete().",
+        " */",
+        "function hook_actions_delete($aid) {","  $1","}"
+    ],
+    "description": "Executes code after an action is deleted.",
+    "scope": "text.php"
+  },
+  "hook_action_info": {
+    "prefix": "hook_action_info",
+    "body": [
+        "/**",
+        " * Implements hook_action_info().",
+        " */",
+        "function hook_action_info() {","  $1","}"
+    ],
+    "description": "Declares information about actions.",
+    "scope": "text.php"
+  },
+  "hook_action_info_alter": {
+    "prefix": "hook_action_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_action_info_alter().",
+        " */",
+        "function hook_action_info_alter(&$actions) {","  $1","}"
+    ],
+    "description": "Alters the actions declared by another module.",
+    "scope": "text.php"
+  },
+  "hook_admin_paths": {
+    "prefix": "hook_admin_paths",
+    "body": [
+        "/**",
+        " * Implements hook_admin_paths().",
+        " */",
+        "function hook_admin_paths() {","  $1","}"
+    ],
+    "description": "Define administrative paths.",
+    "scope": "text.php"
+  },
+  "hook_admin_paths_alter": {
+    "prefix": "hook_admin_paths_alter",
+    "body": [
+        "/**",
+        " * Implements hook_admin_paths_alter().",
+        " */",
+        "function hook_admin_paths_alter(&$paths)hook_aggregator_fetch($feed) {","  $1","}"
+    ],
+    "description": "Redefine administrative paths defined by other modules.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_fetch": {
+    "prefix": "hook_aggregator_fetch",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_fetch().",
+        " */",
+        "function hook_aggregator_fetch_info() {","  $1","}"
+    ],
+    "description": "Create an alternative fetcher for aggregator.module.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_fetch_info": {
+    "prefix": "hook_aggregator_fetch_info",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_fetch_info().",
+        " */",
+        "function hook_aggregator_parse($feed) {","  $1","}"
+    ],
+    "description": "Specify the title and short description of your fetcher.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_parse": {
+    "prefix": "hook_aggregator_parse",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_parse().",
+        " */",
+        "function hook_aggregator_parse_info() {","  $1","}"
+    ],
+    "description": "Create an alternative parser for aggregator module.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_parse_info": {
+    "prefix": "hook_aggregator_parse_info",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_parse_info().",
+        " */",
+        "function hook_aggregator_process($feed) {","  $1","}"
+    ],
+    "description": "Specify the title and short description of your parser.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_process": {
+    "prefix": "hook_aggregator_process",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_process().",
+        " */",
+        "function hook_aggregator_process_info() {","  $1","}"
+    ],
+    "description": "Create a processor for aggregator.module.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_process_info": {
+    "prefix": "hook_aggregator_process_info",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_process_info().",
+        " */",
+        "function hook_aggregator_process_info() {","  $1","}"
+    ],
+    "description": "Specify the title and short description of your processor.",
+    "scope": "text.php"
+  },
+  "hook_aggregator_remove": {
+    "prefix": "hook_aggregator_remove",
+    "body": [
+        "/**",
+        " * Implements hook_aggregator_remove().",
+        " */",
+        "function hook_aggregator_remove($feed) {","  $1","}"
+    ],
+    "description": "Remove stored feed data.",
+    "scope": "text.php"
+  },
+  "hook_ajax_render_alter": {
+    "prefix": "hook_ajax_render_alter",
+    "body": [
+        "/**",
+        " * Implements hook_ajax_render_alter().",
+        " */",
+        "function hook_ajax_render_alter(array &$data) {","  $1","}"
+    ],
+    "description": "Alter the commands that are sent to the user through the Ajax framework.",
+    "scope": "text.php"
+  },
+  "hook_archiver_info": {
+    "prefix": "hook_archiver_info",
+    "body": [
+        "/**",
+        " * Implements hook_archiver_info().",
+        " */",
+        "function hook_archiver_info() {","  $1","}"
+    ],
+    "description": "Declare archivers to the system.",
+    "scope": "text.php"
+  },
+  "hook_archiver_info_alter": {
+    "prefix": "hook_archiver_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_archiver_info_alter().",
+        " */",
+        "function hook_archiver_info_alter(&$info) {","  $1","}"
+    ],
+    "description": "Alter archiver information declared by other modules.",
+    "scope": "text.php"
+  },
+  "hook_batch_alter": {
+    "prefix": "hook_batch_alter",
+    "body": [
+        "/**",
+        " * Implements hook_batch_alter().",
+        " */",
+        "function hook_batch_alter(&$batch) {","  $1","}"
+    ],
+    "description": "Alter batch information before a batch is processed.",
+    "scope": "text.php"
+  },
+  "hook_block_cid_parts_alter": {
+    "prefix": "hook_block_cid_parts_alter",
+    "body": [
+        "/**",
+        " * Implements hook_block_cid_parts_alter().",
+        " */",
+        "function hook_block_cid_parts_alter(&$cid_parts, $block) {","  $1","}"
+    ],
+    "description": "Act on block cache ID (cid) parts before the cid is generated.",
+    "scope": "text.php"
+  },
+  "hook_block_configure": {
+    "prefix": "hook_block_configure",
+    "body": [
+        "/**",
+        " * Implements hook_block_configure().",
+        " */",
+        "function hook_block_configure($delta = '') {","  $1","}"
+    ],
+    "description": "Define a configuration form for a block.",
+    "scope": "text.php"
+  },
+  "hook_block_info": {
+    "prefix": "hook_block_info",
+    "body": [
+        "/**",
+        " * Implements hook_block_info().",
+        " */",
+        "function hook_block_info() {","  $1","}"
+    ],
+    "description": "Define all blocks provided by the module.",
+    "scope": "text.php"
+  },
+  "hook_block_info_alter": {
+    "prefix": "hook_block_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_block_info_alter().",
+        " */",
+        "function hook_block_info_alter(&$blocks, $theme, $code_blocks) {","  $1","}"
+    ],
+    "description": "Change block definition before saving to the database.",
+    "scope": "text.php"
+  },
+  "hook_block_list_alter": {
+    "prefix": "hook_block_list_alter",
+    "body": [
+        "/**",
+        " * Implements hook_block_list_alter().",
+        " */",
+        "function hook_block_list_alter(&$blocks) {","  $1","}"
+    ],
+    "description": "Act on blocks prior to rendering.",
+    "scope": "text.php"
+  },
+  "hook_block_save": {
+    "prefix": "hook_block_save",
+    "body": [
+        "/**",
+        " * Implements hook_block_save().",
+        " */",
+        "function hook_block_save($delta = '', $edit = array()) {","  $1","}"
+    ],
+    "description": "Save the configuration options from hook_block_configure().",
+    "scope": "text.php"
+  },
+  "hook_block_view": {
+    "prefix": "hook_block_view",
+    "body": [
+        "/**",
+        " * Implements hook_block_view().",
+        " */",
+        "function hook_block_view($delta = '') {","  $1","}"
+    ],
+    "description": "Return a rendered or renderable view of a block.",
+    "scope": "text.php"
+  },
+  "hook_block_view_alter": {
+    "prefix": "hook_block_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_block_view_alter().",
+        " */",
+        "function hook_block_view_alter(array &$build, \\Drupal\\Core\\Block\\BlockPluginInterface $block) {","  $1","}"
+    ],
+    "description": "Perform alterations to the content of a block.",
+    "scope": "text.php"
+  },
+  "hook_block_view_MODULE_DELTA_alter": {
+    "prefix": "hook_block_view_MODULE_DELTA_alter",
+    "body": [
+        "/**",
+        " * Implements hook_block_view_MODULE_DELTA_alter().",
+        " */",
+        "function hook_block_view_MODULE_DELTA_alter(&$data, $block) {","  $1","}"
+    ],
+    "description": "Perform alterations to a specific block.",
+    "scope": "text.php"
+  },
+  "hook_boot": {
+    "prefix": "hook_boot",
+    "body": [
+        "/**",
+        " * Implements hook_boot().",
+        " */",
+        "function hook_boot() {","  $1","}"
+    ],
+    "description": "Perform setup tasks for all page requests.",
+    "scope": "text.php"
+  },
+  "hook_comment_delete": {
+    "prefix": "hook_comment_delete",
+    "body": [
+        "/**",
+        " * Implements hook_comment_delete().",
+        " */",
+        "function hook_comment_delete($comment) {","  $1","}"
+    ],
+    "description": "The comment is being deleted by the moderator.",
+    "scope": "text.php"
+  },
+  "hook_comment_insert": {
+    "prefix": "hook_comment_insert",
+    "body": [
+        "/**",
+        " * Implements hook_comment_insert().",
+        " */",
+        "function hook_comment_insert($comment) {","  $1","}"
+    ],
+    "description": "The comment is being inserted.",
+    "scope": "text.php"
+  },
+  "hook_comment_load": {
+    "prefix": "hook_comment_load",
+    "body": [
+        "/**",
+        " * Implements hook_comment_load().",
+        " */",
+        "function hook_comment_load($comments) {","  $1","}"
+    ],
+    "description": "Comments are being loaded from the database.",
+    "scope": "text.php"
+  },
+  "hook_comment_presave": {
+    "prefix": "hook_comment_presave",
+    "body": [
+        "/**",
+        " * Implements hook_comment_presave().",
+        " */",
+        "function hook_comment_presave($comment) {","  $1","}"
+    ],
+    "description": "The comment passed validation and is about to be saved.",
+    "scope": "text.php"
+  },
+  "hook_comment_publish": {
+    "prefix": "hook_comment_publish",
+    "body": [
+        "/**",
+        " * Implements hook_comment_publish().",
+        " */",
+        "function hook_comment_publish($comment) {","  $1","}"
+    ],
+    "description": "The comment is being published by the moderator.",
+    "scope": "text.php"
+  },
+  "hook_comment_unpublish": {
+    "prefix": "hook_comment_unpublish",
+    "body": [
+        "/**",
+        " * Implements hook_comment_unpublish().",
+        " */",
+        "function hook_comment_unpublish($comment) {","  $1","}"
+    ],
+    "description": "The comment is being unpublished by the moderator.",
+    "scope": "text.php"
+  },
+  "hook_comment_update": {
+    "prefix": "hook_comment_update",
+    "body": [
+        "/**",
+        " * Implements hook_comment_update().",
+        " */",
+        "function hook_comment_update($comment) {","  $1","}"
+    ],
+    "description": "The comment is being updated.",
+    "scope": "text.php"
+  },
+  "hook_comment_view": {
+    "prefix": "hook_comment_view",
+    "body": [
+        "/**",
+        " * Implements hook_comment_view().",
+        " */",
+        "function hook_comment_view($comment, $view_mode, $langcode) {","  $1","}"
+    ],
+    "description": "The comment is being viewed. This hook can be used to add additional data to the comment before theming.",
+    "scope": "text.php"
+  },
+  "hook_comment_view_alter": {
+    "prefix": "hook_comment_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_comment_view_alter().",
+        " */",
+        "function hook_comment_view_alter(&$build) {","  $1","}"
+    ],
+    "description": "The comment was built; the module may modify the structured content.",
+    "scope": "text.php"
+  },
+  "hook_contextual_links_view_alter": {
+    "prefix": "hook_contextual_links_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_contextual_links_view_alter().",
+        " */",
+        "function hook_contextual_links_view_alter(&$element, $items) {","  $1","}"
+    ],
+    "description": "Alter a contextual links element before it is rendered.",
+    "scope": "text.php"
+  },
+  "hook_countries_alter": {
+    "prefix": "hook_countries_alter",
+    "body": [
+        "/**",
+        " * Implements hook_countries_alter().",
+        " */",
+        "function hook_countries_alter(&$countries)hook_cron() {","  $1","}"
+    ],
+    "description": "Alter the default country list.",
+    "scope": "text.php"
+  },
+  "hook_cron": {
+    "prefix": "hook_cron",
+    "body": [
+        "/**",
+        " * Implements hook_cron().",
+        " */",
+        "function hook_cron() {","  $1","}"
+    ],
+    "description": "Perform periodic actions.",
+    "scope": "text.php"
+  },
+  "hook_cron_queue_info": {
+    "prefix": "hook_cron_queue_info",
+    "body": [
+        "/**",
+        " * Implements hook_cron_queue_info().",
+        " */",
+        "function hook_cron_queue_info() {","  $1","}"
+    ],
+    "description": "Declare queues holding items that need to be run periodically.",
+    "scope": "text.php"
+  },
+  "hook_cron_queue_info_alter": {
+    "prefix": "hook_cron_queue_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_cron_queue_info_alter().",
+        " */",
+        "function hook_cron_queue_info_alter(&$queues) {","  $1","}"
+    ],
+    "description": "Alter cron queue information before cron runs.",
+    "scope": "text.php"
+  },
+  "hook_css_alter": {
+    "prefix": "hook_css_alter",
+    "body": [
+        "/**",
+        " * Implements hook_css_alter().",
+        " */",
+        "function hook_css_alter(&$css) {","  $1","}"
+    ],
+    "description": "Alter CSS files before they are output on the page.",
+    "scope": "text.php"
+  },
+  "hook_custom_theme": {
+    "prefix": "hook_custom_theme",
+    "body": [
+        "/**",
+        " * Implements hook_custom_theme().",
+        " */",
+        "function hook_custom_theme() {","  $1","}"
+    ],
+    "description": "Return the machine-readable name of the theme to use for the current page.",
+    "scope": "text.php"
+  },
+  "hook_dashboard_regions": {
+    "prefix": "hook_dashboard_regions",
+    "body": [
+        "/**",
+        " * Implements hook_dashboard_regions().",
+        " */",
+        "function hook_dashboard_regions() {","  $1","}"
+    ],
+    "description": "Add regions to the dashboard.",
+    "scope": "text.php"
+  },
+  "hook_dashboard_regions_alter": {
+    "prefix": "hook_dashboard_regions_alter",
+    "body": [
+        "/**",
+        " * Implements hook_dashboard_regions_alter().",
+        " */",
+        "function hook_dashboard_regions_alter(&$regions) {","  $1","}"
+    ],
+    "description": "Alter dashboard regions provided by modules.",
+    "scope": "text.php"
+  },
+  "hook_date_formats": {
+    "prefix": "hook_date_formats",
+    "body": [
+        "/**",
+        " * Implements hook_date_formats().",
+        " */",
+        "function hook_date_formats() {","  $1","}"
+    ],
+    "description": "Define additional date formats.",
+    "scope": "text.php"
+  },
+  "hook_date_formats_alter": {
+    "prefix": "hook_date_formats_alter",
+    "body": [
+        "/**",
+        " * Implements hook_date_formats_alter().",
+        " */",
+        "function hook_date_formats_alter(&$formats) {","  $1","}"
+    ],
+    "description": "Alter date formats declared by another module.",
+    "scope": "text.php"
+  },
+  "hook_date_format_types": {
+    "prefix": "hook_date_format_types",
+    "body": [
+        "/**",
+        " * Implements hook_date_format_types().",
+        " */",
+        "function hook_date_format_types() {","  $1","}"
+    ],
+    "description": "Define additional date types.",
+    "scope": "text.php"
+  },
+  "hook_date_format_types_alter": {
+    "prefix": "hook_date_format_types_alter",
+    "body": [
+        "/**",
+        " * Implements hook_date_format_types_alter().",
+        " */",
+        "function hook_date_format_types_alter(&$types) {","  $1","}"
+    ],
+    "description": "Modify existing date types.",
+    "scope": "text.php"
+  },
+  "hook_delete": {
+    "prefix": "hook_delete",
+    "body": [
+        "/**",
+        " * Implements hook_delete().",
+        " */",
+        "function hook_delete($node)hook_disable() {","  $1","}"
+    ],
+    "description": "Respond to node deletion.",
+    "scope": "text.php"
+  },
+  "hook_disable": {
+    "prefix": "hook_disable",
+    "body": [
+        "/**",
+        " * Implements hook_disable().",
+        " */",
+        "function hook_disable() {","  $1","}"
+    ],
+    "description": "Perform necessary actions before module is disabled.",
+    "scope": "text.php"
+  },
+  "hook_drupal_goto_alter": {
+    "prefix": "hook_drupal_goto_alter",
+    "body": [
+        "/**",
+        " * Implements hook_drupal_goto_alter().",
+        " */",
+        "function hook_drupal_goto_alter(&$path, &$options, &$http_response_code) {","  $1","}"
+    ],
+    "description": "Change the page the user is sent to by drupal_goto().",
+    "scope": "text.php"
+  },
+  "hook_element_info": {
+    "prefix": "hook_element_info",
+    "body": [
+        "/**",
+        " * Implements hook_element_info().",
+        " */",
+        "function hook_element_info() {","  $1","}"
+    ],
+    "description": "Allows modules to declare their own Form API element types and specify their default values.",
+    "scope": "text.php"
+  },
+  "hook_element_info_alter": {
+    "prefix": "hook_element_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_element_info_alter().",
+        " */",
+        "function hook_element_info_alter(array &$types) {","  $1","}"
+    ],
+    "description": "Alter the element type information returned from modules.",
+    "scope": "text.php"
+  },
+  "hook_enable": {
+    "prefix": "hook_enable",
+    "body": [
+        "/**",
+        " * Implements hook_enable().",
+        " */",
+        "function hook_enable() {","  $1","}"
+    ],
+    "description": "Perform necessary actions after module is enabled.",
+    "scope": "text.php"
+  },
+  "hook_entity_delete": {
+    "prefix": "hook_entity_delete",
+    "body": [
+        "/**",
+        " * Implements hook_entity_delete().",
+        " */",
+        "function hook_entity_delete(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
+    ],
+    "description": "Act on entities when deleted.",
+    "scope": "text.php"
+  },
+  "hook_entity_info": {
+    "prefix": "hook_entity_info",
+    "body": [
+        "/**",
+        " * Implements hook_entity_info().",
+        " */",
+        "function hook_entity_info() {","  $1","}"
+    ],
+    "description": "Inform the base system and the Field API about one or more entity types.",
+    "scope": "text.php"
+  },
+  "hook_entity_info_alter": {
+    "prefix": "hook_entity_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_entity_info_alter().",
+        " */",
+        "function hook_entity_info_alter(&$entity_info) {","  $1","}"
+    ],
+    "description": "Alter the entity info.",
+    "scope": "text.php"
+  },
+  "hook_entity_insert": {
+    "prefix": "hook_entity_insert",
+    "body": [
+        "/**",
+        " * Implements hook_entity_insert().",
+        " */",
+        "function hook_entity_insert(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
+    ],
+    "description": "Act on entities when inserted.",
+    "scope": "text.php"
+  },
+  "hook_entity_load": {
+    "prefix": "hook_entity_load",
+    "body": [
+        "/**",
+        " * Implements hook_entity_load().",
+        " */",
+        "function hook_entity_load(array $entities, $entity_type_id) {","  $1","}"
+    ],
+    "description": "Act on entities when loaded.",
+    "scope": "text.php"
+  },
+  "hook_entity_prepare_view": {
+    "prefix": "hook_entity_prepare_view",
+    "body": [
+        "/**",
+        " * Implements hook_entity_prepare_view().",
+        " */",
+        "function hook_entity_prepare_view($entity_type_id, array $entities, array $displays, $view_mode) {","  $1","}"
+    ],
+    "description": "Act on entities as they are being prepared for view.",
+    "scope": "text.php"
+  },
+  "hook_entity_presave": {
+    "prefix": "hook_entity_presave",
+    "body": [
+        "/**",
+        " * Implements hook_entity_presave().",
+        " */",
+        "function hook_entity_presave(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
+    ],
+    "description": "Act on an entity before it is about to be created or updated.",
+    "scope": "text.php"
+  },
+  "hook_entity_query_alter": {
+    "prefix": "hook_entity_query_alter",
+    "body": [
+        "/**",
+        " * Implements hook_entity_query_alter().",
+        " */",
+        "function hook_entity_query_alter(\\Drupal\\Core\\Entity\\Query\\QueryInterface $query) {","  $1","}"
+    ],
+    "description": "Alter or execute an EntityFieldQuery.",
+    "scope": "text.php"
+  },
+  "hook_entity_update": {
+    "prefix": "hook_entity_update",
+    "body": [
+        "/**",
+        " * Implements hook_entity_update().",
+        " */",
+        "function hook_entity_update(Drupal\\Core\\Entity\\EntityInterface $entity) {","  $1","}"
+    ],
+    "description": "Act on entities when updated.",
+    "scope": "text.php"
+  },
+  "hook_entity_view": {
+    "prefix": "hook_entity_view",
+    "body": [
+        "/**",
+        " * Implements hook_entity_view().",
+        " */",
+        "function hook_entity_view(array &$build, \\Drupal\\Core\\Entity\\EntityInterface $entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface $display, $view_mode) {","  $1","}"
+    ],
+    "description": "Act on entities being assembled before rendering.",
+    "scope": "text.php"
+  },
+  "hook_entity_view_alter": {
+    "prefix": "hook_entity_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_entity_view_alter().",
+        " */",
+        "function hook_entity_view_alter(array &$build, Drupal\\Core\\Entity\\EntityInterface $entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface $display) {","  $1","}"
+    ],
+    "description": "Alter the results of ENTITY_view().",
+    "scope": "text.php"
+  },
+  "hook_entity_view_mode_alter": {
+    "prefix": "hook_entity_view_mode_alter",
+    "body": [
+        "/**",
+        " * Implements hook_entity_view_mode_alter().",
+        " */",
+        "function hook_entity_view_mode_alter(&$view_mode, Drupal\\Core\\Entity\\EntityInterface $entity, $context) {","  $1","}"
+    ],
+    "description": "Change the view mode of an entity that is being displayed.",
+    "scope": "text.php"
+  },
+  "hook_exit": {
+    "prefix": "hook_exit",
+    "body": [
+        "/**",
+        " * Implements hook_exit().",
+        " */",
+        "function hook_exit($destination = NULL) {","  $1","}"
+    ],
+    "description": "Perform cleanup tasks.",
+    "scope": "text.php"
+  },
+  "hook_field_access": {
+    "prefix": "hook_field_access",
+    "body": [
+        "/**",
+        " * Implements hook_field_access().",
+        " */",
+        "function hook_field_access($op, $field, $entity_type, $entity, $account) {","  $1","}"
+    ],
+    "description": "Determine whether the user has access to a given field.",
+    "scope": "text.php"
+  },
+  "hook_field_attach_create_bundle": {
+    "prefix": "hook_field_attach_create_bundle",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_create_bundle().",
+        " */",
+        "function hook_field_attach_create_bundle($entity_type, $bundle) {","  $1","}"
+    ],
+    "description": "Act on field_attach_create_bundle().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_delete": {
+    "prefix": "hook_field_attach_delete",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_delete().",
+        " */",
+        "function hook_field_attach_delete($entity_type, $entity) {","  $1","}"
+    ],
+    "description": "Act on field_attach_delete().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_delete_bundle": {
+    "prefix": "hook_field_attach_delete_bundle",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_delete_bundle().",
+        " */",
+        "function hook_field_attach_delete_bundle($entity_type, $bundle, $instances) {","  $1","}"
+    ],
+    "description": "Act on field_attach_delete_bundle.",
+    "scope": "text.php"
+  },
+  "hook_field_attach_delete_revision": {
+    "prefix": "hook_field_attach_delete_revision",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_delete_revision().",
+        " */",
+        "function hook_field_attach_delete_revision($entity_type, $entity) {","  $1","}"
+    ],
+    "description": "Act on field_attach_delete_revision().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_form": {
+    "prefix": "hook_field_attach_form",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_form().",
+        " */",
+        "function hook_field_attach_form($entity_type, $entity, &$form, &$form_state, $langcode) {","  $1","}"
+    ],
+    "description": "Act on field_attach_form().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_insert": {
+    "prefix": "hook_field_attach_insert",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_insert().",
+        " */",
+        "function hook_field_attach_insert($entity_type, $entity) {","  $1","}"
+    ],
+    "description": "Act on field_attach_insert().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_load": {
+    "prefix": "hook_field_attach_load",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_load().",
+        " */",
+        "function hook_field_attach_load($entity_type, $entities, $age, $options) {","  $1","}"
+    ],
+    "description": "Act on field_attach_load().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_prepare_translation_alter": {
+    "prefix": "hook_field_attach_prepare_translation_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_prepare_translation_alter().",
+        " */",
+        "function hook_field_attach_prepare_translation_alter(&$entity, $context) {","  $1","}"
+    ],
+    "description": "Perform alterations on field_attach_prepare_translation().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_preprocess_alter": {
+    "prefix": "hook_field_attach_preprocess_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_preprocess_alter().",
+        " */",
+        "function hook_field_attach_preprocess_alter(&$variables, $context) {","  $1","}"
+    ],
+    "description": "Alter field_attach_preprocess() variables.",
+    "scope": "text.php"
+  },
+  "hook_field_attach_presave": {
+    "prefix": "hook_field_attach_presave",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_presave().",
+        " */",
+        "function hook_field_attach_presave($entity_type, $entity) {","  $1","}"
+    ],
+    "description": "Act on field_attach_presave().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_purge": {
+    "prefix": "hook_field_attach_purge",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_purge().",
+        " */",
+        "function hook_field_attach_purge($entity_type, $entity, $field, $instance) {","  $1","}"
+    ],
+    "description": "Act on field_purge_data().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_rename_bundle": {
+    "prefix": "hook_field_attach_rename_bundle",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_rename_bundle().",
+        " */",
+        "function hook_field_attach_rename_bundle($entity_type, $bundle_old, $bundle_new) {","  $1","}"
+    ],
+    "description": "Act on field_attach_rename_bundle().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_submit": {
+    "prefix": "hook_field_attach_submit",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_submit().",
+        " */",
+        "function hook_field_attach_submit($entity_type, $entity, $form, &$form_state) {","  $1","}"
+    ],
+    "description": "Act on field_attach_submit().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_update": {
+    "prefix": "hook_field_attach_update",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_update().",
+        " */",
+        "function hook_field_attach_update($entity_type, $entity) {","  $1","}"
+    ],
+    "description": "Act on field_attach_update().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_validate": {
+    "prefix": "hook_field_attach_validate",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_validate().",
+        " */",
+        "function hook_field_attach_validate($entity_type, $entity, &$errors) {","  $1","}"
+    ],
+    "description": "Act on field_attach_validate().",
+    "scope": "text.php"
+  },
+  "hook_field_attach_view_alter": {
+    "prefix": "hook_field_attach_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_attach_view_alter().",
+        " */",
+        "function hook_field_attach_view_alter(&$output, $context) {","  $1","}"
+    ],
+    "description": "Perform alterations on field_attach_view() or field_view_field().",
+    "scope": "text.php"
+  },
+  "hook_field_available_languages_alter": {
+    "prefix": "hook_field_available_languages_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_available_languages_alter().",
+        " */",
+        "function hook_field_available_languages_alter(&$languages, $context) {","  $1","}"
+    ],
+    "description": "Alter field_available_languages() values.",
+    "scope": "text.php"
+  },
+  "hook_field_create_field": {
+    "prefix": "hook_field_create_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_create_field().",
+        " */",
+        "function hook_field_create_field($field) {","  $1","}"
+    ],
+    "description": "Act on a field being created.",
+    "scope": "text.php"
+  },
+  "hook_field_create_instance": {
+    "prefix": "hook_field_create_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_create_instance().",
+        " */",
+        "function hook_field_create_instance($instance) {","  $1","}"
+    ],
+    "description": "Act on a field instance being created.",
+    "scope": "text.php"
+  },
+  "hook_field_delete": {
+    "prefix": "hook_field_delete",
+    "body": [
+        "/**",
+        " * Implements hook_field_delete().",
+        " */",
+        "function hook_field_delete($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Define custom delete behavior for this module's field data.",
+    "scope": "text.php"
+  },
+  "hook_field_delete_field": {
+    "prefix": "hook_field_delete_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_delete_field().",
+        " */",
+        "function hook_field_delete_field($field) {","  $1","}"
+    ],
+    "description": "Act on a field being deleted.",
+    "scope": "text.php"
+  },
+  "hook_field_delete_instance": {
+    "prefix": "hook_field_delete_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_delete_instance().",
+        " */",
+        "function hook_field_delete_instance($instance) {","  $1","}"
+    ],
+    "description": "Act on a field instance being deleted.",
+    "scope": "text.php"
+  },
+  "hook_field_delete_revision": {
+    "prefix": "hook_field_delete_revision",
+    "body": [
+        "/**",
+        " * Implements hook_field_delete_revision().",
+        " */",
+        "function hook_field_delete_revision($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Define custom revision delete behavior for this module's field types.",
+    "scope": "text.php"
+  },
+  "hook_field_display_alter": {
+    "prefix": "hook_field_display_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_display_alter().",
+        " */",
+        "function hook_field_display_alter(&$display, $context) {","  $1","}"
+    ],
+    "description": "Alters the display settings of a field before it gets displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_display_ENTITY_TYPE_alter": {
+    "prefix": "hook_field_display_ENTITY_TYPE_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_display_ENTITY_TYPE_alter().",
+        " */",
+        "function hook_field_display_ENTITY_TYPE_alter(&$display, $context) {","  $1","}"
+    ],
+    "description": "Alters the display settings of a field on a given entity type before it gets displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_extra_fields": {
+    "prefix": "hook_field_extra_fields",
+    "body": [
+        "/**",
+        " * Implements hook_field_extra_fields().",
+        " */",
+        "function hook_field_extra_fields() {","  $1","}"
+    ],
+    "description": "Exposes pseudo-field components on fieldable entities.",
+    "scope": "text.php"
+  },
+  "hook_field_extra_fields_alter": {
+    "prefix": "hook_field_extra_fields_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_extra_fields_alter().",
+        " */",
+        "function hook_field_extra_fields_alter(&$info) {","  $1","}"
+    ],
+    "description": "Alter pseudo-field components on fieldable entities.",
+    "scope": "text.php"
+  },
+  "hook_field_extra_fields_display_alter": {
+    "prefix": "hook_field_extra_fields_display_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_extra_fields_display_alter().",
+        " */",
+        "function hook_field_extra_fields_display_alter(&$displays, $context) {","  $1","}"
+    ],
+    "description": "Alters the display settings of pseudo-fields before an entity is displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_formatter_info": {
+    "prefix": "hook_field_formatter_info",
+    "body": [
+        "/**",
+        " * Implements hook_field_formatter_info().",
+        " */",
+        "function hook_field_formatter_info() {","  $1","}"
+    ],
+    "description": "Expose Field API formatter types.",
+    "scope": "text.php"
+  },
+  "hook_field_formatter_info_alter": {
+    "prefix": "hook_field_formatter_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_formatter_info_alter().",
+        " */",
+        "function hook_field_formatter_info_alter(array &$info) {","  $1","}"
+    ],
+    "description": "Perform alterations on Field API formatter types.",
+    "scope": "text.php"
+  },
+  "hook_field_formatter_prepare_view": {
+    "prefix": "hook_field_formatter_prepare_view",
+    "body": [
+        "/**",
+        " * Implements hook_field_formatter_prepare_view().",
+        " */",
+        "function hook_field_formatter_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items, $displays) {","  $1","}"
+    ],
+    "description": "Allow formatters to load information for field values being displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_formatter_view": {
+    "prefix": "hook_field_formatter_view",
+    "body": [
+        "/**",
+        " * Implements hook_field_formatter_view().",
+        " */",
+        "function hook_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {","  $1","}"
+    ],
+    "description": "Build a renderable array for a field value.",
+    "scope": "text.php"
+  },
+  "hook_field_info": {
+    "prefix": "hook_field_info",
+    "body": [
+        "/**",
+        " * Implements hook_field_info().",
+        " */",
+        "function hook_field_info() {","  $1","}"
+    ],
+    "description": "Define Field API field types.",
+    "scope": "text.php"
+  },
+  "hook_field_info_alter": {
+    "prefix": "hook_field_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_info_alter().",
+        " */",
+        "function hook_field_info_alter(&$info) {","  $1","}"
+    ],
+    "description": "Perform alterations on Field API field types.",
+    "scope": "text.php"
+  },
+  "hook_field_info_max_weight": {
+    "prefix": "hook_field_info_max_weight",
+    "body": [
+        "/**",
+        " * Implements hook_field_info_max_weight().",
+        " */",
+        "function hook_field_info_max_weight($entity_type, $bundle, $context, $context_mode) {","  $1","}"
+    ],
+    "description": "Returns the maximum weight for the entity components handled by the module.",
+    "scope": "text.php"
+  },
+  "hook_field_insert": {
+    "prefix": "hook_field_insert",
+    "body": [
+        "/**",
+        " * Implements hook_field_insert().",
+        " */",
+        "function hook_field_insert($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Define custom insert behavior for this module's field data.",
+    "scope": "text.php"
+  },
+  "hook_field_is_empty": {
+    "prefix": "hook_field_is_empty",
+    "body": [
+        "/**",
+        " * Implements hook_field_is_empty().",
+        " */",
+        "function hook_field_is_empty($item, $field) {","  $1","}"
+    ],
+    "description": "Define what constitutes an empty item for a field type.",
+    "scope": "text.php"
+  },
+  "hook_field_language_alter": {
+    "prefix": "hook_field_language_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_language_alter().",
+        " */",
+        "function hook_field_language_alter(&$display_language, $context) {","  $1","}"
+    ],
+    "description": "Perform alterations on field_language() values.",
+    "scope": "text.php"
+  },
+  "hook_field_load": {
+    "prefix": "hook_field_load",
+    "body": [
+        "/**",
+        " * Implements hook_field_load().",
+        " */",
+        "function hook_field_load($entity_type, $entities, $field, $instances, $langcode, &$items, $age) {","  $1","}"
+    ],
+    "description": "Define custom load behavior for this module's field types.",
+    "scope": "text.php"
+  },
+  "hook_field_prepare_translation": {
+    "prefix": "hook_field_prepare_translation",
+    "body": [
+        "/**",
+        " * Implements hook_field_prepare_translation().",
+        " */",
+        "function hook_field_prepare_translation($entity_type, $entity, $field, $instance, $langcode, &$items, $source_entity, $source_langcode) {","  $1","}"
+    ],
+    "description": "Define custom prepare_translation behavior for this module's field types.",
+    "scope": "text.php"
+  },
+  "hook_field_prepare_view": {
+    "prefix": "hook_field_prepare_view",
+    "body": [
+        "/**",
+        " * Implements hook_field_prepare_view().",
+        " */",
+        "function hook_field_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Prepare field values prior to display.",
+    "scope": "text.php"
+  },
+  "hook_field_presave": {
+    "prefix": "hook_field_presave",
+    "body": [
+        "/**",
+        " * Implements hook_field_presave().",
+        " */",
+        "function hook_field_presave($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Define custom presave behavior for this module's field types.",
+    "scope": "text.php"
+  },
+  "hook_field_purge_field": {
+    "prefix": "hook_field_purge_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_purge_field().",
+        " */",
+        "function hook_field_purge_field(\\Drupal\\field\\Entity\\FieldConfig $field) {","  $1","}"
+    ],
+    "description": "Acts when a field record is being purged.",
+    "scope": "text.php"
+  },
+  "hook_field_purge_instance": {
+    "prefix": "hook_field_purge_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_purge_instance().",
+        " */",
+        "function hook_field_purge_instance($instance) {","  $1","}"
+    ],
+    "description": "Acts when a field instance is being purged.",
+    "scope": "text.php"
+  },
+  "hook_field_read_field": {
+    "prefix": "hook_field_read_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_read_field().",
+        " */",
+        "function hook_field_read_field($field) {","  $1","}"
+    ],
+    "description": "Act on field records being read from the database.",
+    "scope": "text.php"
+  },
+  "hook_field_read_instance": {
+    "prefix": "hook_field_read_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_read_instance().",
+        " */",
+        "function hook_field_read_instance($instance) {","  $1","}"
+    ],
+    "description": "Act on a field record being read from the database.",
+    "scope": "text.php"
+  },
+  "hook_field_schema": {
+    "prefix": "hook_field_schema",
+    "body": [
+        "/**",
+        " * Implements hook_field_schema().",
+        " */",
+        "function hook_field_schema($field) {","  $1","}"
+    ],
+    "description": "Define the Field API schema for a field structure.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_create_field": {
+    "prefix": "hook_field_storage_create_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_create_field().",
+        " */",
+        "function hook_field_storage_create_field($field) {","  $1","}"
+    ],
+    "description": "Act on creation of a new field.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_delete": {
+    "prefix": "hook_field_storage_delete",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_delete().",
+        " */",
+        "function hook_field_storage_delete($entity_type, $entity, $fields) {","  $1","}"
+    ],
+    "description": "Delete all field data for an entity.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_delete_field": {
+    "prefix": "hook_field_storage_delete_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_delete_field().",
+        " */",
+        "function hook_field_storage_delete_field($field) {","  $1","}"
+    ],
+    "description": "Act on deletion of a field.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_delete_instance": {
+    "prefix": "hook_field_storage_delete_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_delete_instance().",
+        " */",
+        "function hook_field_storage_delete_instance($instance) {","  $1","}"
+    ],
+    "description": "Act on deletion of a field instance.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_delete_revision": {
+    "prefix": "hook_field_storage_delete_revision",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_delete_revision().",
+        " */",
+        "function hook_field_storage_delete_revision($entity_type, $entity, $fields) {","  $1","}"
+    ],
+    "description": "Delete a single revision of field data for an entity.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_details": {
+    "prefix": "hook_field_storage_details",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_details().",
+        " */",
+        "function hook_field_storage_details($field) {","  $1","}"
+    ],
+    "description": "Reveal the internal details about the storage for a field.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_details_alter": {
+    "prefix": "hook_field_storage_details_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_details_alter().",
+        " */",
+        "function hook_field_storage_details_alter(&$details, $field) {","  $1","}"
+    ],
+    "description": "Perform alterations on Field API storage details.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_info": {
+    "prefix": "hook_field_storage_info",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_info().",
+        " */",
+        "function hook_field_storage_info() {","  $1","}"
+    ],
+    "description": "Expose Field API storage backends.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_info_alter": {
+    "prefix": "hook_field_storage_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_info_alter().",
+        " */",
+        "function hook_field_storage_info_alter(&$info) {","  $1","}"
+    ],
+    "description": "Perform alterations on Field API storage types.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_load": {
+    "prefix": "hook_field_storage_load",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_load().",
+        " */",
+        "function hook_field_storage_load($entity_type, $entities, $age, $fields, $options) {","  $1","}"
+    ],
+    "description": "Load field data for a set of entities.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_pre_insert": {
+    "prefix": "hook_field_storage_pre_insert",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_pre_insert().",
+        " */",
+        "function hook_field_storage_pre_insert($entity_type, $entity, &$skip_fields) {","  $1","}"
+    ],
+    "description": "Act before the storage backends insert field data.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_pre_load": {
+    "prefix": "hook_field_storage_pre_load",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_pre_load().",
+        " */",
+        "function hook_field_storage_pre_load($entity_type, $entities, $age, &$skip_fields, $options) {","  $1","}"
+    ],
+    "description": "Act before the storage backends load field data.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_pre_update": {
+    "prefix": "hook_field_storage_pre_update",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_pre_update().",
+        " */",
+        "function hook_field_storage_pre_update($entity_type, $entity, &$skip_fields) {","  $1","}"
+    ],
+    "description": "Act before the storage backends update field data.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_purge": {
+    "prefix": "hook_field_storage_purge",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_purge().",
+        " */",
+        "function hook_field_storage_purge($entity_type, $entity, $field, $instance) {","  $1","}"
+    ],
+    "description": "Remove field storage information when field data is purged.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_purge_field": {
+    "prefix": "hook_field_storage_purge_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_purge_field().",
+        " */",
+        "function hook_field_storage_purge_field($field) {","  $1","}"
+    ],
+    "description": "Remove field storage information when a field record is purged.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_purge_field_instance": {
+    "prefix": "hook_field_storage_purge_field_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_purge_field_instance().",
+        " */",
+        "function hook_field_storage_purge_field_instance($instance) {","  $1","}"
+    ],
+    "description": "Remove field storage information when a field instance is purged.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_query": {
+    "prefix": "hook_field_storage_query",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_query().",
+        " */",
+        "function hook_field_storage_query($query) {","  $1","}"
+    ],
+    "description": "Execute an EntityFieldQuery.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_update_field": {
+    "prefix": "hook_field_storage_update_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_update_field().",
+        " */",
+        "function hook_field_storage_update_field($field, $prior_field, $has_data) {","  $1","}"
+    ],
+    "description": "Update the storage information for a field.",
+    "scope": "text.php"
+  },
+  "hook_field_storage_write": {
+    "prefix": "hook_field_storage_write",
+    "body": [
+        "/**",
+        " * Implements hook_field_storage_write().",
+        " */",
+        "function hook_field_storage_write($entity_type, $entity, $op, $fields) {","  $1","}"
+    ],
+    "description": "Write field data for an entity.",
+    "scope": "text.php"
+  },
+  "hook_field_update": {
+    "prefix": "hook_field_update",
+    "body": [
+        "/**",
+        " * Implements hook_field_update().",
+        " */",
+        "function hook_field_update($entity_type, $entity, $field, $instance, $langcode, &$items) {","  $1","}"
+    ],
+    "description": "Define custom update behavior for this module's field data.",
+    "scope": "text.php"
+  },
+  "hook_field_update_field": {
+    "prefix": "hook_field_update_field",
+    "body": [
+        "/**",
+        " * Implements hook_field_update_field().",
+        " */",
+        "function hook_field_update_field($field, $prior_field, $has_data) {","  $1","}"
+    ],
+    "description": "Act on a field being updated.",
+    "scope": "text.php"
+  },
+  "hook_field_update_forbid": {
+    "prefix": "hook_field_update_forbid",
+    "body": [
+        "/**",
+        " * Implements hook_field_update_forbid().",
+        " */",
+        "function hook_field_update_forbid($field, $prior_field, $has_data) {","  $1","}"
+    ],
+    "description": "Forbid a field update from occurring.",
+    "scope": "text.php"
+  },
+  "hook_field_update_instance": {
+    "prefix": "hook_field_update_instance",
+    "body": [
+        "/**",
+        " * Implements hook_field_update_instance().",
+        " */",
+        "function hook_field_update_instance($instance, $prior_instance) {","  $1","}"
+    ],
+    "description": "Act on a field instance being updated.",
+    "scope": "text.php"
+  },
+  "hook_field_validate": {
+    "prefix": "hook_field_validate",
+    "body": [
+        "/**",
+        " * Implements hook_field_validate().",
+        " */",
+        "function hook_field_validate($entity_type, $entity, $field, $instance, $langcode, $items, &$errors) {","  $1","}"
+    ],
+    "description": "Validate this module's field data.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_error": {
+    "prefix": "hook_field_widget_error",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_error().",
+        " */",
+        "function hook_field_widget_error($element, $error, $form, &$form_state) {","  $1","}"
+    ],
+    "description": "Flag a field-level validation error.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_form": {
+    "prefix": "hook_field_widget_form",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_form().",
+        " */",
+        "function hook_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {","  $1","}"
+    ],
+    "description": "Return the form for a single field widget.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_form_alter": {
+    "prefix": "hook_field_widget_form_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_form_alter().",
+        " */",
+        "function hook_field_widget_form_alter(&$element, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $context) {","  $1","}"
+    ],
+    "description": "Alter forms for field widgets provided by other modules.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_info": {
+    "prefix": "hook_field_widget_info",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_info().",
+        " */",
+        "function hook_field_widget_info() {","  $1","}"
+    ],
+    "description": "Expose Field API widget types.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_info_alter": {
+    "prefix": "hook_field_widget_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_info_alter().",
+        " */",
+        "function hook_field_widget_info_alter(array &$info) {","  $1","}"
+    ],
+    "description": "Perform alterations on Field API widget types.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_properties_alter": {
+    "prefix": "hook_field_widget_properties_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_properties_alter().",
+        " */",
+        "function hook_field_widget_properties_alter(&$widget, $context) {","  $1","}"
+    ],
+    "description": "Alters the widget properties of a field instance before it gets displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_properties_ENTITY_TYPE_alter": {
+    "prefix": "hook_field_widget_properties_ENTITY_TYPE_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_properties_ENTITY_TYPE_alter().",
+        " */",
+        "function hook_field_widget_properties_ENTITY_TYPE_alter(&$widget, $context) {","  $1","}"
+    ],
+    "description": "Alters the widget properties of a field instance on a given entity type before it gets displayed.",
+    "scope": "text.php"
+  },
+  "hook_field_widget_WIDGET_TYPE_form_alter": {
+    "prefix": "hook_field_widget_WIDGET_TYPE_form_alter",
+    "body": [
+        "/**",
+        " * Implements hook_field_widget_WIDGET_TYPE_form_alter().",
+        " */",
+        "function hook_field_widget_WIDGET_TYPE_form_alter(&$element, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $context) {","  $1","}"
+    ],
+    "description": "Alter widget forms for a specific widget provided by another module.",
+    "scope": "text.php"
+  },
+  "hook_filetransfer_info": {
+    "prefix": "hook_filetransfer_info",
+    "body": [
+        "/**",
+        " * Implements hook_filetransfer_info().",
+        " */",
+        "function hook_filetransfer_info() {","  $1","}"
+    ],
+    "description": "Register information about FileTransfer classes provided by a module.",
+    "scope": "text.php"
+  },
+  "hook_filetransfer_info_alter": {
+    "prefix": "hook_filetransfer_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_filetransfer_info_alter().",
+        " */",
+        "function hook_filetransfer_info_alter(&$filetransfer_info) {","  $1","}"
+    ],
+    "description": "Alter the FileTransfer class registry.",
+    "scope": "text.php"
+  },
+  "hook_file_copy": {
+    "prefix": "hook_file_copy",
+    "body": [
+        "/**",
+        " * Implements hook_file_copy().",
+        " */",
+        "function hook_file_copy(Drupal\\file\\FileInterface $file, Drupal\\file\\FileInterface $source) {","  $1","}"
+    ],
+    "description": "Respond to a file that has been copied.",
+    "scope": "text.php"
+  },
+  "hook_file_delete": {
+    "prefix": "hook_file_delete",
+    "body": [
+        "/**",
+        " * Implements hook_file_delete().",
+        " */",
+        "function hook_file_delete($file) {","  $1","}"
+    ],
+    "description": "Respond to a file being deleted.",
+    "scope": "text.php"
+  },
+  "hook_file_download": {
+    "prefix": "hook_file_download",
+    "body": [
+        "/**",
+        " * Implements hook_file_download().",
+        " */",
+        "function hook_file_download($uri) {","  $1","}"
+    ],
+    "description": "Control access to private file downloads and specify HTTP headers.",
+    "scope": "text.php"
+  },
+  "hook_file_insert": {
+    "prefix": "hook_file_insert",
+    "body": [
+        "/**",
+        " * Implements hook_file_insert().",
+        " */",
+        "function hook_file_insert($file) {","  $1","}"
+    ],
+    "description": "Respond to a file being added.",
+    "scope": "text.php"
+  },
+  "hook_file_load": {
+    "prefix": "hook_file_load",
+    "body": [
+        "/**",
+        " * Implements hook_file_load().",
+        " */",
+        "function hook_file_load($files) {","  $1","}"
+    ],
+    "description": "Load additional information into file objects.",
+    "scope": "text.php"
+  },
+  "hook_file_mimetype_mapping_alter": {
+    "prefix": "hook_file_mimetype_mapping_alter",
+    "body": [
+        "/**",
+        " * Implements hook_file_mimetype_mapping_alter().",
+        " */",
+        "function hook_file_mimetype_mapping_alter(&$mapping) {","  $1","}"
+    ],
+    "description": "Alter MIME type mappings used to determine MIME type from a file extension.",
+    "scope": "text.php"
+  },
+  "hook_file_move": {
+    "prefix": "hook_file_move",
+    "body": [
+        "/**",
+        " * Implements hook_file_move().",
+        " */",
+        "function hook_file_move(Drupal\\file\\FileInterface $file, Drupal\\file\\FileInterface $source) {","  $1","}"
+    ],
+    "description": "Respond to a file that has been moved.",
+    "scope": "text.php"
+  },
+  "hook_file_presave": {
+    "prefix": "hook_file_presave",
+    "body": [
+        "/**",
+        " * Implements hook_file_presave().",
+        " */",
+        "function hook_file_presave($file) {","  $1","}"
+    ],
+    "description": "Act on a file being inserted or updated.",
+    "scope": "text.php"
+  },
+  "hook_file_update": {
+    "prefix": "hook_file_update",
+    "body": [
+        "/**",
+        " * Implements hook_file_update().",
+        " */",
+        "function hook_file_update($file) {","  $1","}"
+    ],
+    "description": "Respond to a file being updated.",
+    "scope": "text.php"
+  },
+  "hook_file_url_alter": {
+    "prefix": "hook_file_url_alter",
+    "body": [
+        "/**",
+        " * Implements hook_file_url_alter().",
+        " */",
+        "function hook_file_url_alter(&$uri) {","  $1","}"
+    ],
+    "description": "Alter the URL to a file.",
+    "scope": "text.php"
+  },
+  "hook_file_validate": {
+    "prefix": "hook_file_validate",
+    "body": [
+        "/**",
+        " * Implements hook_file_validate().",
+        " */",
+        "function hook_file_validate(Drupal\\file\\FileInterface $file) {","  $1","}"
+    ],
+    "description": "Check that files meet a given criteria.",
+    "scope": "text.php"
+  },
+  "hook_filter_format_disable": {
+    "prefix": "hook_filter_format_disable",
+    "body": [
+        "/**",
+        " * Implements hook_filter_format_disable().",
+        " */",
+        "function hook_filter_format_disable($format) {","  $1","}"
+    ],
+    "description": "Perform actions when a text format has been disabled.",
+    "scope": "text.php"
+  },
+  "hook_filter_format_insert": {
+    "prefix": "hook_filter_format_insert",
+    "body": [
+        "/**",
+        " * Implements hook_filter_format_insert().",
+        " */",
+        "function hook_filter_format_insert($format) {","  $1","}"
+    ],
+    "description": "Perform actions when a new text format has been created.",
+    "scope": "text.php"
+  },
+  "hook_filter_format_update": {
+    "prefix": "hook_filter_format_update",
+    "body": [
+        "/**",
+        " * Implements hook_filter_format_update().",
+        " */",
+        "function hook_filter_format_update($format) {","  $1","}"
+    ],
+    "description": "Perform actions when a text format has been updated.",
+    "scope": "text.php"
+  },
+  "hook_filter_info": {
+    "prefix": "hook_filter_info",
+    "body": [
+        "/**",
+        " * Implements hook_filter_info().",
+        " */",
+        "function hook_filter_info() {","  $1","}"
+    ],
+    "description": "Define content filters.",
+    "scope": "text.php"
+  },
+  "hook_filter_info_alter": {
+    "prefix": "hook_filter_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_filter_info_alter().",
+        " */",
+        "function hook_filter_info_alter(&$info) {","  $1","}"
+    ],
+    "description": "Perform alterations on filter definitions.",
+    "scope": "text.php"
+  },
+  "hook_flush_caches": {
+    "prefix": "hook_flush_caches",
+    "body": [
+        "/**",
+        " * Implements hook_flush_caches().",
+        " */",
+        "function hook_flush_caches() {","  $1","}"
+    ],
+    "description": "Add a list of cache tables to be cleared.",
+    "scope": "text.php"
+  },
+  "hook_form": {
+    "prefix": "hook_form",
+    "body": [
+        "/**",
+        " * Implements hook_form().",
+        " */",
+        "function hook_form($node, &$form_state) {","  $1","}"
+    ],
+    "description": "Display a node editing form.",
+    "scope": "text.php"
+  },
+  "hook_forms": {
+    "prefix": "hook_forms",
+    "body": [
+        "/**",
+        " * Implements hook_forms().",
+        " */",
+        "function hook_forms() {","  $1","}"
+    ],
+    "description": "Map form_ids to form builder functions.",
+    "scope": "text.php"
+  },
+  "hook_form_alter": {
+    "prefix": "hook_form_alter",
+    "body": [
+        "/**",
+        " * Implements hook_form_alter().",
+        " */",
+        "function hook_form_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
+    ],
+    "description": "Perform alterations before a form is rendered.",
+    "scope": "text.php"
+  },
+  "hook_form_BASE_FORM_ID_alter": {
+    "prefix": "hook_form_BASE_FORM_ID_alter",
+    "body": [
+        "/**",
+        " * Implements hook_form_BASE_FORM_ID_alter().",
+        " */",
+        "function hook_form_BASE_FORM_ID_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
+    ],
+    "description": "Provide a form-specific alteration for shared ('base') forms.",
+    "scope": "text.php"
+  },
+  "hook_form_FORM_ID_alter": {
+    "prefix": "hook_form_FORM_ID_alter",
+    "body": [
+        "/**",
+        " * Implements hook_form_FORM_ID_alter().",
+        " */",
+        "function hook_form_FORM_ID_alter(&$form, \\Drupal\\Core\\Form\\FormStateInterface $form_state, $form_id) {","  $1","}"
+    ],
+    "description": "Provide a form-specific alteration instead of the global hook_form_alter().",
+    "scope": "text.php"
+  },
+  "hook_help": {
+    "prefix": "hook_help",
+    "body": [
+        "/**",
+        " * Implements hook_help().",
+        " */",
+        "function hook_help($route_name, \\Drupal\\Core\\Routing\\RouteMatchInterface $route_match) {","  $1","}"
+    ],
+    "description": "Provide online user help.",
+    "scope": "text.php"
+  },
+  "hook_hook_info": {
+    "prefix": "hook_hook_info",
+    "body": [
+        "/**",
+        " * Implements hook_hook_info().",
+        " */",
+        "function hook_hook_info() {","  $1","}"
+    ],
+    "description": "Defines one or more hooks that are exposed by a module.",
+    "scope": "text.php"
+  },
+  "hook_hook_info_alter": {
+    "prefix": "hook_hook_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_hook_info_alter().",
+        " */",
+        "function hook_hook_info_alter(&$hooks) {","  $1","}"
+    ],
+    "description": "Alter information from hook_hook_info().",
+    "scope": "text.php"
+  },
+  "hook_html_head_alter": {
+    "prefix": "hook_html_head_alter",
+    "body": [
+        "/**",
+        " * Implements hook_html_head_alter().",
+        " */",
+        "function hook_html_head_alter(&$head_elements) {","  $1","}"
+    ],
+    "description": "Alter XHTML HEAD tags before they are rendered by drupal_get_html_head().",
+    "scope": "text.php"
+  },
+  "hook_image_default_styles": {
+    "prefix": "hook_image_default_styles",
+    "body": [
+        "/**",
+        " * Implements hook_image_default_styles().",
+        " */",
+        "function hook_image_default_styles() {","  $1","}"
+    ],
+    "description": "Provide module-based image styles for reuse throughout Drupal.",
+    "scope": "text.php"
+  },
+  "hook_image_effect_info": {
+    "prefix": "hook_image_effect_info",
+    "body": [
+        "/**",
+        " * Implements hook_image_effect_info().",
+        " */",
+        "function hook_image_effect_info() {","  $1","}"
+    ],
+    "description": "Define information about image effects provided by a module.",
+    "scope": "text.php"
+  },
+  "hook_image_effect_info_alter": {
+    "prefix": "hook_image_effect_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_image_effect_info_alter().",
+        " */",
+        "function hook_image_effect_info_alter(&$effects) {","  $1","}"
+    ],
+    "description": "Alter the information provided in hook_image_effect_info().",
+    "scope": "text.php"
+  },
+  "hook_image_styles_alter": {
+    "prefix": "hook_image_styles_alter",
+    "body": [
+        "/**",
+        " * Implements hook_image_styles_alter().",
+        " */",
+        "function hook_image_styles_alter(&$styles) {","  $1","}"
+    ],
+    "description": "Modify any image styles provided by other modules or the user.",
+    "scope": "text.php"
+  },
+  "hook_image_style_delete": {
+    "prefix": "hook_image_style_delete",
+    "body": [
+        "/**",
+        " * Implements hook_image_style_delete().",
+        " */",
+        "function hook_image_style_delete($style) {","  $1","}"
+    ],
+    "description": "Respond to image style deletion.",
+    "scope": "text.php"
+  },
+  "hook_image_style_flush": {
+    "prefix": "hook_image_style_flush",
+    "body": [
+        "/**",
+        " * Implements hook_image_style_flush().",
+        " */",
+        "function hook_image_style_flush($style) {","  $1","}"
+    ],
+    "description": "Respond to image style flushing.",
+    "scope": "text.php"
+  },
+  "hook_image_style_save": {
+    "prefix": "hook_image_style_save",
+    "body": [
+        "/**",
+        " * Implements hook_image_style_save().",
+        " */",
+        "function hook_image_style_save($style) {","  $1","}"
+    ],
+    "description": "Respond to image style updating.",
+    "scope": "text.php"
+  },
+  "hook_image_toolkits": {
+    "prefix": "hook_image_toolkits",
+    "body": [
+        "/**",
+        " * Implements hook_image_toolkits().",
+        " */",
+        "function hook_image_toolkits()hook_init() {","  $1","}"
+    ],
+    "description": "Define image toolkits provided by this module.",
+    "scope": "text.php"
+  },
+  "hook_init": {
+    "prefix": "hook_init",
+    "body": [
+        "/**",
+        " * Implements hook_init().",
+        " */",
+        "function hook_insert($node) {","  $1","}"
+    ],
+    "description": "Perform setup tasks for non-cached page requests.",
+    "scope": "text.php"
+  },
+  "hook_insert": {
+    "prefix": "hook_insert",
+    "body": [
+        "/**",
+        " * Implements hook_insert().",
+        " */",
+        "function hook_install() {","  $1","}"
+    ],
+    "description": "Respond to creation of a new node.",
+    "scope": "text.php"
+  },
+  "hook_install": {
+    "prefix": "hook_install",
+    "body": [
+        "/**",
+        " * Implements hook_install().",
+        " */",
+        "function hook_install_tasks(&$install_state) {","  $1","}"
+    ],
+    "description": "Perform setup tasks when the module is installed.",
+    "scope": "text.php"
+  },
+  "hook_install_tasks": {
+    "prefix": "hook_install_tasks",
+    "body": [
+        "/**",
+        " * Implements hook_install_tasks().",
+        " */",
+        "function hook_install_tasks(&$install_state) {","  $1","}"
+    ],
+    "description": "Return an array of tasks to be performed by an installation profile.",
+    "scope": "text.php"
+  },
+  "hook_install_tasks_alter": {
+    "prefix": "hook_install_tasks_alter",
+    "body": [
+        "/**",
+        " * Implements hook_install_tasks_alter().",
+        " */",
+        "function hook_install_tasks_alter(&$tasks, $install_state) {","  $1","}"
+    ],
+    "description": "Alter the full list of installation tasks.",
+    "scope": "text.php"
+  },
+  "hook_js_alter": {
+    "prefix": "hook_js_alter",
+    "body": [
+        "/**",
+        " * Implements hook_js_alter().",
+        " */",
+        "function hook_js_alter(&$javascript, \\Drupal\\Core\\Asset\\AttachedAssetsInterface $assets) {","  $1","}"
+    ],
+    "description": "Perform necessary alterations to the JavaScript before it is presented on the page.",
+    "scope": "text.php"
+  },
+  "hook_language_fallback_candidates_alter": {
+    "prefix": "hook_language_fallback_candidates_alter",
+    "body": [
+        "/**",
+        " * Implements hook_language_fallback_candidates_alter().",
+        " */",
+        "function hook_language_fallback_candidates_alter(array &$candidates, array $context) {","  $1","}"
+    ],
+    "description": "Perform alterations on the language fallback candidates.",
+    "scope": "text.php"
+  },
+  "hook_language_init": {
+    "prefix": "hook_language_init",
+    "body": [
+        "/**",
+        " * Implements hook_language_init().",
+        " */",
+        "function hook_language_init() {","  $1","}"
+    ],
+    "description": "Allows modules to act after language initialization has been performed.",
+    "scope": "text.php"
+  },
+  "hook_language_negotiation_info": {
+    "prefix": "hook_language_negotiation_info",
+    "body": [
+        "/**",
+        " * Implements hook_language_negotiation_info().",
+        " */",
+        "function hook_language_negotiation_info() {","  $1","}"
+    ],
+    "description": "Define language negotiation providers.",
+    "scope": "text.php"
+  },
+  "hook_language_negotiation_info_alter": {
+    "prefix": "hook_language_negotiation_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_language_negotiation_info_alter().",
+        " */",
+        "function hook_language_negotiation_info_alter(array &$negotiation_info) {","  $1","}"
+    ],
+    "description": "Perform alterations on language negoiation providers.",
+    "scope": "text.php"
+  },
+  "hook_language_switch_links_alter": {
+    "prefix": "hook_language_switch_links_alter",
+    "body": [
+        "/**",
+        " * Implements hook_language_switch_links_alter().",
+        " */",
+        "function hook_language_switch_links_alter(array &$links, $type, $path) {","  $1","}"
+    ],
+    "description": "Perform alterations on language switcher links.",
+    "scope": "text.php"
+  },
+  "hook_language_types_info": {
+    "prefix": "hook_language_types_info",
+    "body": [
+        "/**",
+        " * Implements hook_language_types_info().",
+        " */",
+        "function hook_language_types_info() {","  $1","}"
+    ],
+    "description": "Define language types.",
+    "scope": "text.php"
+  },
+  "hook_language_types_info_alter": {
+    "prefix": "hook_language_types_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_language_types_info_alter().",
+        " */",
+        "function hook_language_types_info_alter(array &$language_types) {","  $1","}"
+    ],
+    "description": "Perform alterations on language types.",
+    "scope": "text.php"
+  },
+  "hook_library": {
+    "prefix": "hook_library",
+    "body": [
+        "/**",
+        " * Implements hook_library().",
+        " */",
+        "function hook_library() {","  $1","}"
+    ],
+    "description": "Registers JavaScript/CSS libraries associated with a module.",
+    "scope": "text.php"
+  },
+  "hook_library_alter": {
+    "prefix": "hook_library_alter",
+    "body": [
+        "/**",
+        " * Implements hook_library_alter().",
+        " */",
+        "function hook_library_alter(&$libraries, $module) {","  $1","}"
+    ],
+    "description": "Alters the JavaScript/CSS library registry.",
+    "scope": "text.php"
+  },
+  "hook_load": {
+    "prefix": "hook_load",
+    "body": [
+        "/**",
+        " * Implements hook_load().",
+        " */",
+        "function hook_load($nodes) {","  $1","}"
+    ],
+    "description": "Act on nodes being loaded from the database.",
+    "scope": "text.php"
+  },
+  "hook_locale": {
+    "prefix": "hook_locale",
+    "body": [
+        "/**",
+        " * Implements hook_locale().",
+        " */",
+        "function hook_locale($op = 'groups') {","  $1","}"
+    ],
+    "description": "Allows modules to define their own text groups that can be translated.",
+    "scope": "text.php"
+  },
+  "hook_mail": {
+    "prefix": "hook_mail",
+    "body": [
+        "/**",
+        " * Implements hook_mail().",
+        " */",
+        "function hook_mail($key, &$message, $params) {","  $1","}"
+    ],
+    "description": "Prepare a message based on parameters; called from drupal_mail().",
+    "scope": "text.php"
+  },
+  "hook_mail_alter": {
+    "prefix": "hook_mail_alter",
+    "body": [
+        "/**",
+        " * Implements hook_mail_alter().",
+        " */",
+        "function hook_mail_alter(&$message) {","  $1","}"
+    ],
+    "description": "Alter an email message created with the drupal_mail() function.",
+    "scope": "text.php"
+  },
+  "hook_menu": {
+    "prefix": "hook_menu",
+    "body": [
+        "/**",
+        " * Implements hook_menu().",
+        " */",
+        "function hook_menu($may_cache) {","  $1","}"
+    ],
+    "description": "Define menu items and page callbacks.",
+    "scope": "text.php"
+  },
+  "hook_menu_alter": {
+    "prefix": "hook_menu_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_alter().",
+        " */",
+        "function hook_menu_alter(&$items) {","  $1","}"
+    ],
+    "description": "Alter the data being saved to the {menu_router} table after hook_menu is invoked.",
+    "scope": "text.php"
+  },
+  "hook_menu_breadcrumb_alter": {
+    "prefix": "hook_menu_breadcrumb_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_breadcrumb_alter().",
+        " */",
+        "function hook_menu_breadcrumb_alter(&$active_trail, $item) {","  $1","}"
+    ],
+    "description": "Alter links in the active trail before it is rendered as the breadcrumb.",
+    "scope": "text.php"
+  },
+  "hook_menu_contextual_links_alter": {
+    "prefix": "hook_menu_contextual_links_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_contextual_links_alter().",
+        " */",
+        "function hook_menu_contextual_links_alter(&$links, $router_item, $root_path) {","  $1","}"
+    ],
+    "description": "Alter contextual links before they are rendered.",
+    "scope": "text.php"
+  },
+  "hook_menu_delete": {
+    "prefix": "hook_menu_delete",
+    "body": [
+        "/**",
+        " * Implements hook_menu_delete().",
+        " */",
+        "function hook_menu_delete($menu) {","  $1","}"
+    ],
+    "description": "Respond to a custom menu deletion.",
+    "scope": "text.php"
+  },
+  "hook_menu_get_item_alter": {
+    "prefix": "hook_menu_get_item_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_get_item_alter().",
+        " */",
+        "function hook_menu_get_item_alter(&$router_item, $path, $original_map) {","  $1","}"
+    ],
+    "description": "Alter a menu router item right after it has been retrieved from the database or cache.",
+    "scope": "text.php"
+  },
+  "hook_menu_insert": {
+    "prefix": "hook_menu_insert",
+    "body": [
+        "/**",
+        " * Implements hook_menu_insert().",
+        " */",
+        "function hook_menu_insert($menu) {","  $1","}"
+    ],
+    "description": "Respond to a custom menu creation.",
+    "scope": "text.php"
+  },
+  "hook_menu_link_alter": {
+    "prefix": "hook_menu_link_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_link_alter().",
+        " */",
+        "function hook_menu_link_alter(&$item, $menu) {","  $1","}"
+    ],
+    "description": "Alter the data being saved to the {menu_links} table by menu_link_save().",
+    "scope": "text.php"
+  },
+  "hook_menu_link_delete": {
+    "prefix": "hook_menu_link_delete",
+    "body": [
+        "/**",
+        " * Implements hook_menu_link_delete().",
+        " */",
+        "function hook_menu_link_delete($link) {","  $1","}"
+    ],
+    "description": "Inform modules that a menu link has been deleted.",
+    "scope": "text.php"
+  },
+  "hook_menu_link_insert": {
+    "prefix": "hook_menu_link_insert",
+    "body": [
+        "/**",
+        " * Implements hook_menu_link_insert().",
+        " */",
+        "function hook_menu_link_insert($link) {","  $1","}"
+    ],
+    "description": "Inform modules that a menu link has been created.",
+    "scope": "text.php"
+  },
+  "hook_menu_link_update": {
+    "prefix": "hook_menu_link_update",
+    "body": [
+        "/**",
+        " * Implements hook_menu_link_update().",
+        " */",
+        "function hook_menu_link_update($link) {","  $1","}"
+    ],
+    "description": "Inform modules that a menu link has been updated.",
+    "scope": "text.php"
+  },
+  "hook_menu_local_tasks_alter": {
+    "prefix": "hook_menu_local_tasks_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_local_tasks_alter().",
+        " */",
+        "function hook_menu_local_tasks_alter(&$data, $route_name) {","  $1","}"
+    ],
+    "description": "Alter tabs and actions displayed on the page before they are rendered.",
+    "scope": "text.php"
+  },
+  "hook_menu_site_status_alter": {
+    "prefix": "hook_menu_site_status_alter",
+    "body": [
+        "/**",
+        " * Implements hook_menu_site_status_alter().",
+        " */",
+        "function hook_menu_site_status_alter(&$menu_site_status, $path) {","  $1","}"
+    ],
+    "description": "Control site status before menu dispatching.",
+    "scope": "text.php"
+  },
+  "hook_menu_update": {
+    "prefix": "hook_menu_update",
+    "body": [
+        "/**",
+        " * Implements hook_menu_update().",
+        " */",
+        "function hook_menu_update($menu) {","  $1","}"
+    ],
+    "description": "Respond to a custom menu update.",
+    "scope": "text.php"
+  },
+  "hook_modules_disabled": {
+    "prefix": "hook_modules_disabled",
+    "body": [
+        "/**",
+        " * Implements hook_modules_disabled().",
+        " */",
+        "function hook_modules_disabled($modules) {","  $1","}"
+    ],
+    "description": "Perform necessary actions after modules are disabled.",
+    "scope": "text.php"
+  },
+  "hook_modules_enabled": {
+    "prefix": "hook_modules_enabled",
+    "body": [
+        "/**",
+        " * Implements hook_modules_enabled().",
+        " */",
+        "function hook_modules_enabled($modules) {","  $1","}"
+    ],
+    "description": "Perform necessary actions after modules are enabled.",
+    "scope": "text.php"
+  },
+  "hook_modules_installed": {
+    "prefix": "hook_modules_installed",
+    "body": [
+        "/**",
+        " * Implements hook_modules_installed().",
+        " */",
+        "function hook_modules_installed($modules) {","  $1","}"
+    ],
+    "description": "Perform necessary actions after modules are installed.",
+    "scope": "text.php"
+  },
+  "hook_modules_uninstalled": {
+    "prefix": "hook_modules_uninstalled",
+    "body": [
+        "/**",
+        " * Implements hook_modules_uninstalled().",
+        " */",
+        "function hook_modules_uninstalled($modules) {","  $1","}"
+    ],
+    "description": "Perform necessary actions after modules are uninstalled.",
+    "scope": "text.php"
+  },
+  "hook_module_implements_alter": {
+    "prefix": "hook_module_implements_alter",
+    "body": [
+        "/**",
+        " * Implements hook_module_implements_alter().",
+        " */",
+        "function hook_module_implements_alter(&$implementations, $hook) {","  $1","}"
+    ],
+    "description": "Alter the registry of modules implementing a hook.",
+    "scope": "text.php"
+  },
+  "hook_multilingual_settings_changed": {
+    "prefix": "hook_multilingual_settings_changed",
+    "body": [
+        "/**",
+        " * Implements hook_multilingual_settings_changed().",
+        " */",
+        "function hook_multilingual_settings_changed()hook_node_access(\\Drupal\\node\\NodeInterface $node, $op, \\Drupal\\Core\\Session\\AccountInterface $account) {","  $1","}"
+    ],
+    "description": "Allow modules to react to language settings changes.",
+    "scope": "text.php"
+  },
+  "hook_node_access": {
+    "prefix": "hook_node_access",
+    "body": [
+        "/**",
+        " * Implements hook_node_access().",
+        " */",
+        "function hook_node_access_records(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
+    ],
+    "description": "Control access to a node.",
+    "scope": "text.php"
+  },
+  "hook_node_access_records": {
+    "prefix": "hook_node_access_records",
+    "body": [
+        "/**",
+        " * Implements hook_node_access_records().",
+        " */",
+        "function hook_node_access_records_alter(&$grants, Drupal\\node\\NodeInterface $node) {","  $1","}"
+    ],
+    "description": "Set permissions for a node to be written to the database.",
+    "scope": "text.php"
+  },
+  "hook_node_access_records_alter": {
+    "prefix": "hook_node_access_records_alter",
+    "body": [
+        "/**",
+        " * Implements hook_node_access_records_alter().",
+        " */",
+        "function hook_node_access_records_alter(&$grants, $node) {","  $1","}"
+    ],
+    "description": "Alter permissions for a node before it is written to the database.",
+    "scope": "text.php"
+  },
+  "hook_node_delete": {
+    "prefix": "hook_node_delete",
+    "body": [
+        "/**",
+        " * Implements hook_node_delete().",
+        " */",
+        "function hook_node_delete($node) {","  $1","}"
+    ],
+    "description": "Respond to node deletion.",
+    "scope": "text.php"
+  },
+  "hook_node_grants": {
+    "prefix": "hook_node_grants",
+    "body": [
+        "/**",
+        " * Implements hook_node_grants().",
+        " */",
+        "function hook_node_grants(\\Drupal\\Core\\Session\\AccountInterface $account, $op) {","  $1","}"
+    ],
+    "description": "Inform the node access system what permissions the user has.",
+    "scope": "text.php"
+  },
+  "hook_node_grants_alter": {
+    "prefix": "hook_node_grants_alter",
+    "body": [
+        "/**",
+        " * Implements hook_node_grants_alter().",
+        " */",
+        "function hook_node_grants_alter(&$grants, \\Drupal\\Core\\Session\\AccountInterface $account, $op) {","  $1","}"
+    ],
+    "description": "Alter user access rules when trying to view, edit or delete a node.",
+    "scope": "text.php"
+  },
+  "hook_node_info": {
+    "prefix": "hook_node_info",
+    "body": [
+        "/**",
+        " * Implements hook_node_info().",
+        " */",
+        "function hook_node_info() {","  $1","}"
+    ],
+    "description": "Define module-provided node types.",
+    "scope": "text.php"
+  },
+  "hook_node_insert": {
+    "prefix": "hook_node_insert",
+    "body": [
+        "/**",
+        " * Implements hook_node_insert().",
+        " */",
+        "function hook_node_insert($node) {","  $1","}"
+    ],
+    "description": "Respond to creation of a new node.",
+    "scope": "text.php"
+  },
+  "hook_node_load": {
+    "prefix": "hook_node_load",
+    "body": [
+        "/**",
+        " * Implements hook_node_load().",
+        " */",
+        "function hook_node_load($nodes, $types) {","  $1","}"
+    ],
+    "description": "Act on arbitrary nodes being loaded from the database.",
+    "scope": "text.php"
+  },
+  "hook_node_operations": {
+    "prefix": "hook_node_operations",
+    "body": [
+        "/**",
+        " * Implements hook_node_operations().",
+        " */",
+        "function hook_node_operations() {","  $1","}"
+    ],
+    "description": "Add mass node operations.",
+    "scope": "text.php"
+  },
+  "hook_node_prepare": {
+    "prefix": "hook_node_prepare",
+    "body": [
+        "/**",
+        " * Implements hook_node_prepare().",
+        " */",
+        "function hook_node_prepare($node) {","  $1","}"
+    ],
+    "description": "Act on a node object about to be shown on the add/edit form.",
+    "scope": "text.php"
+  },
+  "hook_node_presave": {
+    "prefix": "hook_node_presave",
+    "body": [
+        "/**",
+        " * Implements hook_node_presave().",
+        " */",
+        "function hook_node_presave($node) {","  $1","}"
+    ],
+    "description": "Act on a node being inserted or updated.",
+    "scope": "text.php"
+  },
+  "hook_node_revision_delete": {
+    "prefix": "hook_node_revision_delete",
+    "body": [
+        "/**",
+        " * Implements hook_node_revision_delete().",
+        " */",
+        "function hook_node_revision_delete($node) {","  $1","}"
+    ],
+    "description": "Respond to deletion of a node revision.",
+    "scope": "text.php"
+  },
+  "hook_node_search_result": {
+    "prefix": "hook_node_search_result",
+    "body": [
+        "/**",
+        " * Implements hook_node_search_result().",
+        " */",
+        "function hook_node_search_result(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
+    ],
+    "description": "Act on a node being displayed as a search result.",
+    "scope": "text.php"
+  },
+  "hook_node_submit": {
+    "prefix": "hook_node_submit",
+    "body": [
+        "/**",
+        " * Implements hook_node_submit().",
+        " */",
+        "function hook_node_submit($node, $form, &$form_state) {","  $1","}"
+    ],
+    "description": "Act on a node after validated form values have been copied to it.",
+    "scope": "text.php"
+  },
+  "hook_node_type_delete": {
+    "prefix": "hook_node_type_delete",
+    "body": [
+        "/**",
+        " * Implements hook_node_type_delete().",
+        " */",
+        "function hook_node_type_delete($info) {","  $1","}"
+    ],
+    "description": "Respond to node type deletion.",
+    "scope": "text.php"
+  },
+  "hook_node_type_insert": {
+    "prefix": "hook_node_type_insert",
+    "body": [
+        "/**",
+        " * Implements hook_node_type_insert().",
+        " */",
+        "function hook_node_type_insert($info) {","  $1","}"
+    ],
+    "description": "Respond to node type creation.",
+    "scope": "text.php"
+  },
+  "hook_node_type_update": {
+    "prefix": "hook_node_type_update",
+    "body": [
+        "/**",
+        " * Implements hook_node_type_update().",
+        " */",
+        "function hook_node_type_update($info) {","  $1","}"
+    ],
+    "description": "Respond to node type updates.",
+    "scope": "text.php"
+  },
+  "hook_node_update": {
+    "prefix": "hook_node_update",
+    "body": [
+        "/**",
+        " * Implements hook_node_update().",
+        " */",
+        "function hook_node_update($node) {","  $1","}"
+    ],
+    "description": "Respond to updates to a node.",
+    "scope": "text.php"
+  },
+  "hook_node_update_index": {
+    "prefix": "hook_node_update_index",
+    "body": [
+        "/**",
+        " * Implements hook_node_update_index().",
+        " */",
+        "function hook_node_update_index(\\Drupal\\node\\NodeInterface $node) {","  $1","}"
+    ],
+    "description": "Act on a node being indexed for searching.",
+    "scope": "text.php"
+  },
+  "hook_node_validate": {
+    "prefix": "hook_node_validate",
+    "body": [
+        "/**",
+        " * Implements hook_node_validate().",
+        " */",
+        "function hook_node_validate($node, $form, &$form_state) {","  $1","}"
+    ],
+    "description": "Perform node validation before a node is created or updated.",
+    "scope": "text.php"
+  },
+  "hook_node_view": {
+    "prefix": "hook_node_view",
+    "body": [
+        "/**",
+        " * Implements hook_node_view().",
+        " */",
+        "function hook_node_view($node, $view_mode, $langcode) {","  $1","}"
+    ],
+    "description": "Act on a node that is being assembled before rendering.",
+    "scope": "text.php"
+  },
+  "hook_node_view_alter": {
+    "prefix": "hook_node_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_node_view_alter().",
+        " */",
+        "function hook_node_view_alter(&$build) {","  $1","}"
+    ],
+    "description": "Alter the results of node_view().",
+    "scope": "text.php"
+  },
+  "hook_openid": {
+    "prefix": "hook_openid",
+    "body": [
+        "/**",
+        " * Implements hook_openid().",
+        " */",
+        "function hook_openid($op, $request) {","  $1","}"
+    ],
+    "description": "Allow modules to modify the OpenID request parameters.",
+    "scope": "text.php"
+  },
+  "hook_openid_discovery_method_info": {
+    "prefix": "hook_openid_discovery_method_info",
+    "body": [
+        "/**",
+        " * Implements hook_openid_discovery_method_info().",
+        " */",
+        "function hook_openid_discovery_method_info() {","  $1","}"
+    ],
+    "description": "Allow modules to declare OpenID discovery methods.",
+    "scope": "text.php"
+  },
+  "hook_openid_discovery_method_info_alter": {
+    "prefix": "hook_openid_discovery_method_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_openid_discovery_method_info_alter().",
+        " */",
+        "function hook_openid_discovery_method_info_alter(&$methods) {","  $1","}"
+    ],
+    "description": "Allow modules to alter discovery methods.",
+    "scope": "text.php"
+  },
+  "hook_openid_normalization_method_info": {
+    "prefix": "hook_openid_normalization_method_info",
+    "body": [
+        "/**",
+        " * Implements hook_openid_normalization_method_info().",
+        " */",
+        "function hook_openid_normalization_method_info() {","  $1","}"
+    ],
+    "description": "Allow modules to declare OpenID normalization methods.",
+    "scope": "text.php"
+  },
+  "hook_openid_normalization_method_info_alter": {
+    "prefix": "hook_openid_normalization_method_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_openid_normalization_method_info_alter().",
+        " */",
+        "function hook_openid_normalization_method_info_alter(&$methods) {","  $1","}"
+    ],
+    "description": "Allow modules to alter normalization methods.",
+    "scope": "text.php"
+  },
+  "hook_openid_response": {
+    "prefix": "hook_openid_response",
+    "body": [
+        "/**",
+        " * Implements hook_openid_response().",
+        " */",
+        "function hook_openid_response($response, $account) {","  $1","}"
+    ],
+    "description": "Allow modules to act upon a successful OpenID login.",
+    "scope": "text.php"
+  },
+  "hook_overlay_child_initialize": {
+    "prefix": "hook_overlay_child_initialize",
+    "body": [
+        "/**",
+        " * Implements hook_overlay_child_initialize().",
+        " */",
+        "function hook_overlay_child_initialize() {","  $1","}"
+    ],
+    "description": "Allow modules to act when an overlay child window is initialized.",
+    "scope": "text.php"
+  },
+  "hook_overlay_parent_initialize": {
+    "prefix": "hook_overlay_parent_initialize",
+    "body": [
+        "/**",
+        " * Implements hook_overlay_parent_initialize().",
+        " */",
+        "function hook_overlay_parent_initialize() {","  $1","}"
+    ],
+    "description": "Allow modules to act when an overlay parent window is initialized.",
+    "scope": "text.php"
+  },
+  "hook_page_alter": {
+    "prefix": "hook_page_alter",
+    "body": [
+        "/**",
+        " * Implements hook_page_alter().",
+        " */",
+        "function hook_page_alter(&$page) {","  $1","}"
+    ],
+    "description": "Perform alterations before a page is rendered.",
+    "scope": "text.php"
+  },
+  "hook_page_build": {
+    "prefix": "hook_page_build",
+    "body": [
+        "/**",
+        " * Implements hook_page_build().",
+        " */",
+        "function hook_page_build(&$page) {","  $1","}"
+    ],
+    "description": "Add elements to a page before it is rendered.",
+    "scope": "text.php"
+  },
+  "hook_page_delivery_callback_alter": {
+    "prefix": "hook_page_delivery_callback_alter",
+    "body": [
+        "/**",
+        " * Implements hook_page_delivery_callback_alter().",
+        " */",
+        "function hook_page_delivery_callback_alter(&$callback) {","  $1","}"
+    ],
+    "description": "Alters the delivery callback used to send the result of the page callback to the browser.",
+    "scope": "text.php"
+  },
+  "hook_path_delete": {
+    "prefix": "hook_path_delete",
+    "body": [
+        "/**",
+        " * Implements hook_path_delete().",
+        " */",
+        "function hook_path_delete($path) {","  $1","}"
+    ],
+    "description": "Respond to a path being deleted.",
+    "scope": "text.php"
+  },
+  "hook_path_insert": {
+    "prefix": "hook_path_insert",
+    "body": [
+        "/**",
+        " * Implements hook_path_insert().",
+        " */",
+        "function hook_path_insert($path) {","  $1","}"
+    ],
+    "description": "Respond to a path being inserted.",
+    "scope": "text.php"
+  },
+  "hook_path_update": {
+    "prefix": "hook_path_update",
+    "body": [
+        "/**",
+        " * Implements hook_path_update().",
+        " */",
+        "function hook_path_update($path) {","  $1","}"
+    ],
+    "description": "Respond to a path being updated.",
+    "scope": "text.php"
+  },
+  "hook_permission": {
+    "prefix": "hook_permission",
+    "body": [
+        "/**",
+        " * Implements hook_permission().",
+        " */",
+        "function hook_permission() {","  $1","}"
+    ],
+    "description": "Define user permissions.",
+    "scope": "text.php"
+  },
+  "hook_prepare": {
+    "prefix": "hook_prepare",
+    "body": [
+        "/**",
+        " * Implements hook_prepare().",
+        " */",
+        "function hook_prepare($node) {","  $1","}"
+    ],
+    "description": "Act on a node object about to be shown on the add/edit form.",
+    "scope": "text.php"
+  },
+  "hook_query_alter": {
+    "prefix": "hook_query_alter",
+    "body": [
+        "/**",
+        " * Implements hook_query_alter().",
+        " */",
+        "function hook_query_alter(Drupal\\Core\\Database\\Query\\AlterableInterface $query) {","  $1","}"
+    ],
+    "description": "Perform alterations to a structured query.",
+    "scope": "text.php"
+  },
+  "hook_query_TAG_alter": {
+    "prefix": "hook_query_TAG_alter",
+    "body": [
+        "/**",
+        " * Implements hook_query_TAG_alter().",
+        " */",
+        "function hook_query_TAG_alter(Drupal\\Core\\Database\\Query\\AlterableInterface $query) {","  $1","}"
+    ],
+    "description": "Perform alterations to a structured query for a given tag.",
+    "scope": "text.php"
+  },
+  "hook_ranking": {
+    "prefix": "hook_ranking",
+    "body": [
+        "/**",
+        " * Implements hook_ranking().",
+        " */",
+        "function hook_ranking()hook_rdf_mapping() {","  $1","}"
+    ],
+    "description": "Provide additional methods of scoring for core search results for nodes.",
+    "scope": "text.php"
+  },
+  "hook_rdf_mapping": {
+    "prefix": "hook_rdf_mapping",
+    "body": [
+        "/**",
+        " * Implements hook_rdf_mapping().",
+        " */",
+        "function hook_rdf_namespaces() {","  $1","}"
+    ],
+    "description": "Allow modules to define RDF mappings for field bundles.",
+    "scope": "text.php"
+  },
+  "hook_rdf_namespaces": {
+    "prefix": "hook_rdf_namespaces",
+    "body": [
+        "/**",
+        " * Implements hook_rdf_namespaces().",
+        " */",
+        "function hook_rdf_namespaces() {","  $1","}"
+    ],
+    "description": "Allow modules to define namespaces for RDF mappings.",
+    "scope": "text.php"
+  },
+  "hook_registry_files_alter": {
+    "prefix": "hook_registry_files_alter",
+    "body": [
+        "/**",
+        " * Implements hook_registry_files_alter().",
+        " */",
+        "function hook_registry_files_alter(&$files, $modules) {","  $1","}"
+    ],
+    "description": "Perform necessary alterations to the list of files parsed by the registry.",
+    "scope": "text.php"
+  },
+  "hook_requirements": {
+    "prefix": "hook_requirements",
+    "body": [
+        "/**",
+        " * Implements hook_requirements().",
+        " */",
+        "function hook_requirements($phase) {","  $1","}"
+    ],
+    "description": "Check installation requirements and do status reporting.",
+    "scope": "text.php"
+  },
+  "hook_schema": {
+    "prefix": "hook_schema",
+    "body": [
+        "/**",
+        " * Implements hook_schema().",
+        " */",
+        "function hook_schema() {","  $1","}"
+    ],
+    "description": "Define the current version of the database schema.",
+    "scope": "text.php"
+  },
+  "hook_schema_alter": {
+    "prefix": "hook_schema_alter",
+    "body": [
+        "/**",
+        " * Implements hook_schema_alter().",
+        " */",
+        "function hook_schema_alter(&$schema) {","  $1","}"
+    ],
+    "description": "Perform alterations to existing database schemas.",
+    "scope": "text.php"
+  },
+  "hook_search_access": {
+    "prefix": "hook_search_access",
+    "body": [
+        "/**",
+        " * Implements hook_search_access().",
+        " */",
+        "function hook_search_access() {","  $1","}"
+    ],
+    "description": "Define access to a custom search routine.",
+    "scope": "text.php"
+  },
+  "hook_search_admin": {
+    "prefix": "hook_search_admin",
+    "body": [
+        "/**",
+        " * Implements hook_search_admin().",
+        " */",
+        "function hook_search_admin() {","  $1","}"
+    ],
+    "description": "Add elements to the search settings form.",
+    "scope": "text.php"
+  },
+  "hook_search_execute": {
+    "prefix": "hook_search_execute",
+    "body": [
+        "/**",
+        " * Implements hook_search_execute().",
+        " */",
+        "function hook_search_execute($keys = NULL, $conditions = NULL) {","  $1","}"
+    ],
+    "description": "Execute a search for a set of key words.",
+    "scope": "text.php"
+  },
+  "hook_search_info": {
+    "prefix": "hook_search_info",
+    "body": [
+        "/**",
+        " * Implements hook_search_info().",
+        " */",
+        "function hook_search_info() {","  $1","}"
+    ],
+    "description": "Define a custom search type.",
+    "scope": "text.php"
+  },
+  "hook_search_page": {
+    "prefix": "hook_search_page",
+    "body": [
+        "/**",
+        " * Implements hook_search_page().",
+        " */",
+        "function hook_search_page($results) {","  $1","}"
+    ],
+    "description": "Override the rendering of search results.",
+    "scope": "text.php"
+  },
+  "hook_search_preprocess": {
+    "prefix": "hook_search_preprocess",
+    "body": [
+        "/**",
+        " * Implements hook_search_preprocess().",
+        " */",
+        "function hook_search_preprocess($text, $langcode = NULL) {","  $1","}"
+    ],
+    "description": "Preprocess text for search.",
+    "scope": "text.php"
+  },
+  "hook_search_reset": {
+    "prefix": "hook_search_reset",
+    "body": [
+        "/**",
+        " * Implements hook_search_reset().",
+        " */",
+        "function hook_search_reset() {","  $1","}"
+    ],
+    "description": "Take action when the search index is going to be rebuilt.",
+    "scope": "text.php"
+  },
+  "hook_search_status": {
+    "prefix": "hook_search_status",
+    "body": [
+        "/**",
+        " * Implements hook_search_status().",
+        " */",
+        "function hook_search_status() {","  $1","}"
+    ],
+    "description": "Report the status of indexing.",
+    "scope": "text.php"
+  },
+  "hook_shortcut_default_set": {
+    "prefix": "hook_shortcut_default_set",
+    "body": [
+        "/**",
+        " * Implements hook_shortcut_default_set().",
+        " */",
+        "function hook_shortcut_default_set($account) {","  $1","}"
+    ],
+    "description": "Return the name of a default shortcut set for the provided user account.",
+    "scope": "text.php"
+  },
+  "hook_simpletest_alter": {
+    "prefix": "hook_simpletest_alter",
+    "body": [
+        "/**",
+        " * Implements hook_simpletest_alter().",
+        " */",
+        "function hook_simpletest_alter(&$groups)hook_stream_wrappers() {","  $1","}"
+    ],
+    "description": "Alter the list of tests.",
+    "scope": "text.php"
+  },
+  "hook_stream_wrappers": {
+    "prefix": "hook_stream_wrappers",
+    "body": [
+        "/**",
+        " * Implements hook_stream_wrappers().",
+        " */",
+        "function hook_stream_wrappers_alter(&$wrappers) {","  $1","}"
+    ],
+    "description": "Registers PHP stream wrapper implementations associated with a module.",
+    "scope": "text.php"
+  },
+  "hook_stream_wrappers_alter": {
+    "prefix": "hook_stream_wrappers_alter",
+    "body": [
+        "/**",
+        " * Implements hook_stream_wrappers_alter().",
+        " */",
+        "function hook_system_info_alter(array &$info, \\Drupal\\Core\\Extension\\Extension $file, $type) {","  $1","}"
+    ],
+    "description": "Alters the list of PHP stream wrapper implementations.",
+    "scope": "text.php"
+  },
+  "hook_system_info_alter": {
+    "prefix": "hook_system_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_system_info_alter().",
+        " */",
+        "function hook_system_themes_page_alter(&$theme_groups) {","  $1","}"
+    ],
+    "description": "Alter the information parsed from module and theme .info files",
+    "scope": "text.php"
+  },
+  "hook_system_themes_page_alter": {
+    "prefix": "hook_system_themes_page_alter",
+    "body": [
+        "/**",
+        " * Implements hook_system_themes_page_alter().",
+        " */",
+        "function hook_system_themes_page_alter(&$theme_groups) {","  $1","}"
+    ],
+    "description": "Alters theme operation links.",
+    "scope": "text.php"
+  },
+  "hook_system_theme_info": {
+    "prefix": "hook_system_theme_info",
+    "body": [
+        "/**",
+        " * Implements hook_system_theme_info().",
+        " */",
+        "function hook_system_theme_info() {","  $1","}"
+    ],
+    "description": "Return additional themes provided by modules.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_delete": {
+    "prefix": "hook_taxonomy_term_delete",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_delete().",
+        " */",
+        "function hook_taxonomy_term_delete($term) {","  $1","}"
+    ],
+    "description": "Respond to the deletion of taxonomy terms.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_insert": {
+    "prefix": "hook_taxonomy_term_insert",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_insert().",
+        " */",
+        "function hook_taxonomy_term_insert($term) {","  $1","}"
+    ],
+    "description": "Act on taxonomy terms when inserted.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_load": {
+    "prefix": "hook_taxonomy_term_load",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_load().",
+        " */",
+        "function hook_taxonomy_term_load($terms) {","  $1","}"
+    ],
+    "description": "Act on taxonomy terms when loaded.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_presave": {
+    "prefix": "hook_taxonomy_term_presave",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_presave().",
+        " */",
+        "function hook_taxonomy_term_presave($term) {","  $1","}"
+    ],
+    "description": "Act on taxonomy terms before they are saved.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_update": {
+    "prefix": "hook_taxonomy_term_update",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_update().",
+        " */",
+        "function hook_taxonomy_term_update($term) {","  $1","}"
+    ],
+    "description": "Act on taxonomy terms when updated.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_view": {
+    "prefix": "hook_taxonomy_term_view",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_view().",
+        " */",
+        "function hook_taxonomy_term_view($term, $view_mode, $langcode) {","  $1","}"
+    ],
+    "description": "Act on a taxonomy term that is being assembled before rendering.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_term_view_alter": {
+    "prefix": "hook_taxonomy_term_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_term_view_alter().",
+        " */",
+        "function hook_taxonomy_term_view_alter(&$build) {","  $1","}"
+    ],
+    "description": "Alter the results of taxonomy_term_view().",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_vocabulary_delete": {
+    "prefix": "hook_taxonomy_vocabulary_delete",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_vocabulary_delete().",
+        " */",
+        "function hook_taxonomy_vocabulary_delete($vocabulary) {","  $1","}"
+    ],
+    "description": "Respond to the deletion of taxonomy vocabularies.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_vocabulary_insert": {
+    "prefix": "hook_taxonomy_vocabulary_insert",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_vocabulary_insert().",
+        " */",
+        "function hook_taxonomy_vocabulary_insert($vocabulary) {","  $1","}"
+    ],
+    "description": "Act on taxonomy vocabularies when inserted.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_vocabulary_load": {
+    "prefix": "hook_taxonomy_vocabulary_load",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_vocabulary_load().",
+        " */",
+        "function hook_taxonomy_vocabulary_load($vocabularies) {","  $1","}"
+    ],
+    "description": "Act on taxonomy vocabularies when loaded.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_vocabulary_presave": {
+    "prefix": "hook_taxonomy_vocabulary_presave",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_vocabulary_presave().",
+        " */",
+        "function hook_taxonomy_vocabulary_presave($vocabulary) {","  $1","}"
+    ],
+    "description": "Act on taxonomy vocabularies before they are saved.",
+    "scope": "text.php"
+  },
+  "hook_taxonomy_vocabulary_update": {
+    "prefix": "hook_taxonomy_vocabulary_update",
+    "body": [
+        "/**",
+        " * Implements hook_taxonomy_vocabulary_update().",
+        " */",
+        "function hook_taxonomy_vocabulary_update($vocabulary) {","  $1","}"
+    ],
+    "description": "Act on taxonomy vocabularies when updated.",
+    "scope": "text.php"
+  },
+  "hook_test_finished": {
+    "prefix": "hook_test_finished",
+    "body": [
+        "/**",
+        " * Implements hook_test_finished().",
+        " */",
+        "function hook_test_finished($results) {","  $1","}"
+    ],
+    "description": "An individual test has finished.",
+    "scope": "text.php"
+  },
+  "hook_test_group_finished": {
+    "prefix": "hook_test_group_finished",
+    "body": [
+        "/**",
+        " * Implements hook_test_group_finished().",
+        " */",
+        "function hook_test_group_finished() {","  $1","}"
+    ],
+    "description": "A test group has finished.",
+    "scope": "text.php"
+  },
+  "hook_test_group_started": {
+    "prefix": "hook_test_group_started",
+    "body": [
+        "/**",
+        " * Implements hook_test_group_started().",
+        " */",
+        "function hook_test_group_started() {","  $1","}"
+    ],
+    "description": "A test group has started.",
+    "scope": "text.php"
+  },
+  "hook_theme": {
+    "prefix": "hook_theme",
+    "body": [
+        "/**",
+        " * Implements hook_theme().",
+        " */",
+        "function hook_theme($existing, $type, $theme, $path) {","  $1","}"
+    ],
+    "description": "Register a module (or theme's) theme implementations.",
+    "scope": "text.php"
+  },
+  "hook_theme_registry_alter": {
+    "prefix": "hook_theme_registry_alter",
+    "body": [
+        "/**",
+        " * Implements hook_theme_registry_alter().",
+        " */",
+        "function hook_theme_registry_alter(&$theme_registry) {","  $1","}"
+    ],
+    "description": "Alter the theme registry information returned from hook_theme().",
+    "scope": "text.php"
+  },
+  "hook_tokens": {
+    "prefix": "hook_tokens",
+    "body": [
+        "/**",
+        " * Implements hook_tokens().",
+        " */",
+        "function hook_tokens($type, $tokens, array $data, array $options, \\Drupal\\Core\\Render\\BubbleableMetadata $bubbleable_metadata) {","  $1","}"
+    ],
+    "description": "Provide replacement values for placeholder tokens.",
+    "scope": "text.php"
+  },
+  "hook_tokens_alter": {
+    "prefix": "hook_tokens_alter",
+    "body": [
+        "/**",
+        " * Implements hook_tokens_alter().",
+        " */",
+        "function hook_tokens_alter(array &$replacements, array $context, \\Drupal\\Core\\Render\\BubbleableMetadata $bubbleable_metadata) {","  $1","}"
+    ],
+    "description": "Alter replacement values for placeholder tokens.",
+    "scope": "text.php"
+  },
+  "hook_token_info": {
+    "prefix": "hook_token_info",
+    "body": [
+        "/**",
+        " * Implements hook_token_info().",
+        " */",
+        "function hook_token_info() {","  $1","}"
+    ],
+    "description": "Provide information about available placeholder tokens and token types.",
+    "scope": "text.php"
+  },
+  "hook_token_info_alter": {
+    "prefix": "hook_token_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_token_info_alter().",
+        " */",
+        "function hook_token_info_alter(&$data) {","  $1","}"
+    ],
+    "description": "Alter the metadata about available placeholder tokens and token types.",
+    "scope": "text.php"
+  },
+  "hook_translated_menu_link_alter": {
+    "prefix": "hook_translated_menu_link_alter",
+    "body": [
+        "/**",
+        " * Implements hook_translated_menu_link_alter().",
+        " */",
+        "function hook_translated_menu_link_alter(&$item, $map) {","  $1","}"
+    ],
+    "description": "Alter a menu link after it has been translated and before it is rendered.",
+    "scope": "text.php"
+  },
+  "hook_trigger_info": {
+    "prefix": "hook_trigger_info",
+    "body": [
+        "/**",
+        " * Implements hook_trigger_info().",
+        " */",
+        "function Not found: hook_trigger_info {","  $1","}"
+    ],
+    "description": "Declare triggers (events) for users to assign actions to.",
+    "scope": "text.php"
+  },
+  "hook_trigger_info_alter": {
+    "prefix": "hook_trigger_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_trigger_info_alter().",
+        " */",
+        "function Not found: hook_trigger_info_alter {","  $1","}"
+    ],
+    "description": "Alter triggers declared by hook_trigger_info().",
+    "scope": "text.php"
+  },
+  "hook_uninstall": {
+    "prefix": "hook_uninstall",
+    "body": [
+        "/**",
+        " * Implements hook_uninstall().",
+        " */",
+        "function hook_uninstall() {","  $1","}"
+    ],
+    "description": "Remove any information that the module sets.",
+    "scope": "text.php"
+  },
+  "hook_update": {
+    "prefix": "hook_update",
+    "body": [
+        "/**",
+        " * Implements hook_update().",
+        " */",
+        "function hook_update($node) {","  $1","}"
+    ],
+    "description": "Respond to updates to a node.",
+    "scope": "text.php"
+  },
+  "hook_updater_info": {
+    "prefix": "hook_updater_info",
+    "body": [
+        "/**",
+        " * Implements hook_updater_info().",
+        " */",
+        "function hook_updater_info() {","  $1","}"
+    ],
+    "description": "Provide information on Updaters (classes that can update Drupal).",
+    "scope": "text.php"
+  },
+  "hook_updater_info_alter": {
+    "prefix": "hook_updater_info_alter",
+    "body": [
+        "/**",
+        " * Implements hook_updater_info_alter().",
+        " */",
+        "function hook_updater_info_alter(&$updaters) {","  $1","}"
+    ],
+    "description": "Alter the Updater information array.",
+    "scope": "text.php"
+  },
+  "hook_update_dependencies": {
+    "prefix": "hook_update_dependencies",
+    "body": [
+        "/**",
+        " * Implements hook_update_dependencies().",
+        " */",
+        "function hook_update_dependencies() {","  $1","}"
+    ],
+    "description": "Return an array of information about module update dependencies.",
+    "scope": "text.php"
+  },
+  "hook_update_index": {
+    "prefix": "hook_update_index",
+    "body": [
+        "/**",
+        " * Implements hook_update_index().",
+        " */",
+        "function hook_update_index() {","  $1","}"
+    ],
+    "description": "Update the search index for this module.",
+    "scope": "text.php"
+  },
+  "hook_update_last_removed": {
+    "prefix": "hook_update_last_removed",
+    "body": [
+        "/**",
+        " * Implements hook_update_last_removed().",
+        " */",
+        "function hook_update_last_removed() {","  $1","}"
+    ],
+    "description": "Return a number which is no longer available as hook_update_N().",
+    "scope": "text.php"
+  },
+  "hook_update_N": {
+    "prefix": "hook_update_N",
+    "body": [
+        "/**",
+        " * Implements hook_update_N().",
+        " */",
+        "function hook_update_N(&$sandbox) {","  $1","}"
+    ],
+    "description": "Perform a single update.",
+    "scope": "text.php"
+  },
+  "hook_update_projects_alter": {
+    "prefix": "hook_update_projects_alter",
+    "body": [
+        "/**",
+        " * Implements hook_update_projects_alter().",
+        " */",
+        "function hook_update_projects_alter(&$projects) {","  $1","}"
+    ],
+    "description": "Alter the list of projects before fetching data and comparing versions.",
+    "scope": "text.php"
+  },
+  "hook_update_status_alter": {
+    "prefix": "hook_update_status_alter",
+    "body": [
+        "/**",
+        " * Implements hook_update_status_alter().",
+        " */",
+        "function hook_update_status_alter(&$projects) {","  $1","}"
+    ],
+    "description": "Alter the information about available updates for projects.",
+    "scope": "text.php"
+  },
+  "hook_url_inbound_alter": {
+    "prefix": "hook_url_inbound_alter",
+    "body": [
+        "/**",
+        " * Implements hook_url_inbound_alter().",
+        " */",
+        "function hook_url_inbound_alter(&$path, $original_path, $path_language) {","  $1","}"
+    ],
+    "description": "Alters inbound URL requests.",
+    "scope": "text.php"
+  },
+  "hook_url_outbound_alter": {
+    "prefix": "hook_url_outbound_alter",
+    "body": [
+        "/**",
+        " * Implements hook_url_outbound_alter().",
+        " */",
+        "function hook_url_outbound_alter(&$path, &$options, $original_path) {","  $1","}"
+    ],
+    "description": "Alters outbound URLs.",
+    "scope": "text.php"
+  },
+  "hook_username_alter": {
+    "prefix": "hook_username_alter",
+    "body": [
+        "/**",
+        " * Implements hook_username_alter().",
+        " */",
+        "function hook_username_alter(&$name, $account) {","  $1","}"
+    ],
+    "description": "Alter the username that is displayed for a user.",
+    "scope": "text.php"
+  },
+  "hook_user_cancel": {
+    "prefix": "hook_user_cancel",
+    "body": [
+        "/**",
+        " * Implements hook_user_cancel().",
+        " */",
+        "function hook_user_cancel($edit, $account, $method) {","  $1","}"
+    ],
+    "description": "Act on user account cancellations.",
+    "scope": "text.php"
+  },
+  "hook_user_cancel_methods_alter": {
+    "prefix": "hook_user_cancel_methods_alter",
+    "body": [
+        "/**",
+        " * Implements hook_user_cancel_methods_alter().",
+        " */",
+        "function hook_user_cancel_methods_alter(&$methods) {","  $1","}"
+    ],
+    "description": "Modify account cancellation methods.",
+    "scope": "text.php"
+  },
+  "hook_user_categories": {
+    "prefix": "hook_user_categories",
+    "body": [
+        "/**",
+        " * Implements hook_user_categories().",
+        " */",
+        "function hook_user_categories() {","  $1","}"
+    ],
+    "description": "Define a list of user settings or profile information categories.",
+    "scope": "text.php"
+  },
+  "hook_user_delete": {
+    "prefix": "hook_user_delete",
+    "body": [
+        "/**",
+        " * Implements hook_user_delete().",
+        " */",
+        "function hook_user_delete($account) {","  $1","}"
+    ],
+    "description": "Respond to user deletion.",
+    "scope": "text.php"
+  },
+  "hook_user_insert": {
+    "prefix": "hook_user_insert",
+    "body": [
+        "/**",
+        " * Implements hook_user_insert().",
+        " */",
+        "function hook_user_insert(&$edit, $account, $category) {","  $1","}"
+    ],
+    "description": "A user account was created.",
+    "scope": "text.php"
+  },
+  "hook_user_load": {
+    "prefix": "hook_user_load",
+    "body": [
+        "/**",
+        " * Implements hook_user_load().",
+        " */",
+        "function hook_user_load($users) {","  $1","}"
+    ],
+    "description": "Act on user objects when loaded from the database.",
+    "scope": "text.php"
+  },
+  "hook_user_login": {
+    "prefix": "hook_user_login",
+    "body": [
+        "/**",
+        " * Implements hook_user_login().",
+        " */",
+        "function hook_user_login($account) {","  $1","}"
+    ],
+    "description": "The user just logged in.",
+    "scope": "text.php"
+  },
+  "hook_user_logout": {
+    "prefix": "hook_user_logout",
+    "body": [
+        "/**",
+        " * Implements hook_user_logout().",
+        " */",
+        "function hook_user_logout($account) {","  $1","}"
+    ],
+    "description": "The user just logged out.",
+    "scope": "text.php"
+  },
+  "hook_user_operations": {
+    "prefix": "hook_user_operations",
+    "body": [
+        "/**",
+        " * Implements hook_user_operations().",
+        " */",
+        "function hook_user_operations() {","  $1","}"
+    ],
+    "description": "Add mass user operations.",
+    "scope": "text.php"
+  },
+  "hook_user_presave": {
+    "prefix": "hook_user_presave",
+    "body": [
+        "/**",
+        " * Implements hook_user_presave().",
+        " */",
+        "function hook_user_presave(&$edit, $account, $category) {","  $1","}"
+    ],
+    "description": "A user account is about to be created or updated.",
+    "scope": "text.php"
+  },
+  "hook_user_role_delete": {
+    "prefix": "hook_user_role_delete",
+    "body": [
+        "/**",
+        " * Implements hook_user_role_delete().",
+        " */",
+        "function hook_user_role_delete($role) {","  $1","}"
+    ],
+    "description": "Respond to user role deletion.",
+    "scope": "text.php"
+  },
+  "hook_user_role_insert": {
+    "prefix": "hook_user_role_insert",
+    "body": [
+        "/**",
+        " * Implements hook_user_role_insert().",
+        " */",
+        "function hook_user_role_insert($role) {","  $1","}"
+    ],
+    "description": "Respond to creation of a new user role.",
+    "scope": "text.php"
+  },
+  "hook_user_role_presave": {
+    "prefix": "hook_user_role_presave",
+    "body": [
+        "/**",
+        " * Implements hook_user_role_presave().",
+        " */",
+        "function hook_user_role_presave($role) {","  $1","}"
+    ],
+    "description": "Act on a user role being inserted or updated.",
+    "scope": "text.php"
+  },
+  "hook_user_role_update": {
+    "prefix": "hook_user_role_update",
+    "body": [
+        "/**",
+        " * Implements hook_user_role_update().",
+        " */",
+        "function hook_user_role_update($role) {","  $1","}"
+    ],
+    "description": "Respond to updates to a user role.",
+    "scope": "text.php"
+  },
+  "hook_user_update": {
+    "prefix": "hook_user_update",
+    "body": [
+        "/**",
+        " * Implements hook_user_update().",
+        " */",
+        "function hook_user_update(&$edit, $account, $category) {","  $1","}"
+    ],
+    "description": "A user account was updated.",
+    "scope": "text.php"
+  },
+  "hook_user_view": {
+    "prefix": "hook_user_view",
+    "body": [
+        "/**",
+        " * Implements hook_user_view().",
+        " */",
+        "function hook_user_view($account, $view_mode, $langcode) {","  $1","}"
+    ],
+    "description": "The user's account information is being displayed.",
+    "scope": "text.php"
+  },
+  "hook_user_view_alter": {
+    "prefix": "hook_user_view_alter",
+    "body": [
+        "/**",
+        " * Implements hook_user_view_alter().",
+        " */",
+        "function hook_user_view_alter(&$build) {","  $1","}"
+    ],
+    "description": "The user was built; the module may modify the structured content.",
+    "scope": "text.php"
+  },
+  "hook_validate": {
+    "prefix": "hook_validate",
+    "body": [
+        "/**",
+        " * Implements hook_validate().",
+        " */",
+        "function hook_validate($node, $form, &$form_state) {","  $1","}"
+    ],
+    "description": "Perform node validation before a node is created or updated.",
+    "scope": "text.php"
+  },
+  "hook_verify_update_archive": {
+    "prefix": "hook_verify_update_archive",
+    "body": [
+        "/**",
+        " * Implements hook_verify_update_archive().",
+        " */",
+        "function hook_verify_update_archive($project, $archive_file, $directory) {","  $1","}"
+    ],
+    "description": "Verify an archive after it has been downloaded and extracted.",
+    "scope": "text.php"
+  },
+  "hook_view": {
+    "prefix": "hook_view",
+    "body": [
+        "/**",
+        " * Implements hook_view().",
+        " */",
+        "function hook_view($node, $view_mode, $langcode = NULL) {","  $1","}"
+    ],
+    "description": "Display a node.",
+    "scope": "text.php"
+  },
+  "hook_watchdog": {
+    "prefix": "hook_watchdog",
+    "body": [
+        "/**",
+        " * Implements hook_watchdog().",
+        " */",
+        "function hook_watchdog(array $log_entry) {","  $1","}"
+    ],
+    "description": "Log an event message.",
+    "scope": "text.php"
+  },
+  "hook_xmlrpc": {
+    "prefix": "hook_xmlrpc",
+    "body": [
+        "/**",
+        " * Implements hook_xmlrpc().",
+        " */",
+        "function hook_xmlrpc() {","  $1","}"
+    ],
+    "description": "Register XML-RPC callbacks.",
+    "scope": "text.php"
+  },
+  "hook_xmlrpc_alter": {
+    "prefix": "hook_xmlrpc_alter",
+    "body": [
+        "/**",
+        " * Implements hook_xmlrpc_alter().",
+        " */",
+        "function hook_xmlrpc_alter(&$methods)module_hook($module, $hook) {","  $1","}"
+    ],
+    "description": "Alters the definition of XML-RPC methods before they are called.",
+    "scope": "text.php"
+  },
+  "module_hook": {
+    "prefix": "module_hook",
+    "body": [
+        "/**",
+        " * Implements module_hook().",
+        " */",
+        "function module_hook_info() {","  $1","}"
+    ],
+    "description": "Determines whether a module implements a hook.",
+    "scope": "text.php"
+  },
+  "module_hook_info": {
+    "prefix": "module_hook_info",
+    "body": [
+        "/**",
+        " * Implements module_hook_info().",
+        " */",
+        "function module_hook_info() {","  $1","}"
+    ],
+    "description": "Retrieves a list of hooks that are declared through hook_hook_info().",
+    "scope": "text.php"
+  },
+  "module_implements": {
+    "prefix": "module_implements",
+    "body": [
+        "/**",
+        " * Implements module_implements().",
+        " */",
+        "function module_implements($hook) {","  $1","}"
+    ],
+    "description": "Determines which modules are implementing a hook.",
+    "scope": "text.php"
+  },
+  "module_implements_write_cache": {
+    "prefix": "module_implements_write_cache",
+    "body": [
+        "/**",
+        " * Implements module_implements_write_cache().",
+        " */",
+        "function module_implements_write_cache() {","  $1","}"
+    ],
+    "description": "Writes the hook implementation cache.",
+    "scope": "text.php"
+  },
+  "module_invoke": {
+    "prefix": "module_invoke",
+    "body": [
+        "/**",
+        " * Implements module_invoke().",
+        " */",
+        "function module_invoke() {","  $1","}"
+    ],
+    "description": "Invokes a hook in a particular module.",
+    "scope": "text.php"
+  },
+  "module_invoke_all": {
+    "prefix": "module_invoke_all",
+    "body": [
+        "/**",
+        " * Implements module_invoke_all().",
+        " */",
+        "function module_invoke_all() {","  $1","}"
+    ],
+    "description": "Invokes a hook in all enabled modules that implement it.",
+    "scope": "text.php"
+  }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -2007,7 +2007,7 @@
         "/**",
         " * Implements hook_image_toolkits().",
         " */",
-        "function hook_image_toolkits()hook_init() {","  $1","}"
+        "function hook_image_toolkits() {","  $1","}"
     ],
     "description": "Define image toolkits provided by this module.",
     "scope": "text.php"
@@ -2018,7 +2018,7 @@
         "/**",
         " * Implements hook_init().",
         " */",
-        "function hook_insert($node) {","  $1","}"
+        "function hook_init() {","  $1","}"
     ],
     "description": "Perform setup tasks for non-cached page requests.",
     "scope": "text.php"
@@ -2029,7 +2029,7 @@
         "/**",
         " * Implements hook_insert().",
         " */",
-        "function hook_install() {","  $1","}"
+        "function hook_insert($node) {","  $1","}"
     ],
     "description": "Respond to creation of a new node.",
     "scope": "text.php"
@@ -2040,7 +2040,7 @@
         "/**",
         " * Implements hook_install().",
         " */",
-        "function hook_install_tasks(&$install_state) {","  $1","}"
+        "function hook_install() {","  $1","}"
     ],
     "description": "Perform setup tasks when the module is installed.",
     "scope": "text.php"


### PR DESCRIPTION
- Minor syntax changes such that `snippets.json` now complies with json standards
- Fixed following hooks:
  - hook_image_toolkits
  - hook_init
  - hook_insert
  - hook_install

Problem: `hook_init` was inserting `hook_insert`, `hook_insert` was inserting `hook_install`, etc.
